### PR TITLE
Fix: node initialization

### DIFF
--- a/march_gait_scheduler/src/GaitSchedulerNode.cpp
+++ b/march_gait_scheduler/src/GaitSchedulerNode.cpp
@@ -110,15 +110,20 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "gait_scheduler_node");
   ros::NodeHandle n;
 
+  const std::string follow_joint_trajectory_topic = "/march/controller/trajectory/follow_joint_trajectory";
+
   scheduler = new Scheduler();
 
   scheduleGaitActionServer = new ScheduleGaitActionServer(n, "march/gait/schedule", &scheduleGaitCallback, false);
 
   followJointTrajectoryAction = new actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction>(
-      "/march/controller/trajectory/follow_joint_trajectory", true);
+      follow_joint_trajectory_topic, true);
 
   ROS_DEBUG("Wait on joint trajectory action server");
-  followJointTrajectoryAction->waitForServer();
+  while (ros::ok() && !followJointTrajectoryAction->waitForServer(ros::Duration(5.0)))
+  {
+    ROS_INFO_STREAM("Waiting for " << follow_joint_trajectory_topic << " to come up");
+  }
   ROS_DEBUG("Connected to joint trajectory action server");
 
   dynamic_reconfigure::Server<march_gait_scheduler::SchedulerConfig> server;

--- a/march_gait_scheduler/src/GaitSchedulerNode.cpp
+++ b/march_gait_scheduler/src/GaitSchedulerNode.cpp
@@ -1,6 +1,6 @@
 // Copyright 2018 Project March.
 
-#include "ros/ros.h"
+#include <ros/ros.h>
 #include <control_msgs/FollowJointTrajectoryAction.h>
 #include <ros/package.h>
 #include <std_msgs/Float64.h>
@@ -9,16 +9,15 @@
 #include <actionlib/server/simple_action_server.h>
 #include <dynamic_reconfigure/server.h>
 
-#include <march_shared_resources/GaitAction.h>
-#include <march_shared_resources/GaitGoal.h>
-#include <march_gait_scheduler/Scheduler.h>
-#include <march_gait_scheduler/SchedulerConfig.h>
+#include "march_shared_resources/GaitAction.h"
+#include "march_shared_resources/GaitGoal.h"
+#include "march_gait_scheduler/Scheduler.h"
+#include "march_gait_scheduler/SchedulerConfig.h"
 
 typedef actionlib::SimpleActionServer<march_shared_resources::GaitAction> ScheduleGaitActionServer;
-ScheduleGaitActionServer* scheduleGaitActionServer;
+ScheduleGaitActionServer* scheduleGaitActionServer = nullptr;
 actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction>* followJointTrajectoryAction;
-ros::Publisher trajectory_publisher;
-Scheduler* scheduler;
+Scheduler* scheduler = nullptr;
 
 void doneCallback(const actionlib::SimpleClientGoalState& state,
                   const control_msgs::FollowJointTrajectoryResultConstPtr& result)
@@ -38,11 +37,6 @@ void doneCallback(const actionlib::SimpleClientGoalState& state,
   {
     scheduleGaitActionServer->setAborted();
     ROS_WARN("Schedule gait action FAILED, FollowJointTrajectory error_code is %d ", result->error_code);
-
-      trajectory_msgs::JointTrajectory empty_trajectory;
-      empty_trajectory.points.clear();
-      empty_trajectory.joint_names.clear();
-      trajectory_publisher.publish(empty_trajectory);
   }
 }
 
@@ -118,31 +112,23 @@ int main(int argc, char** argv)
 
   scheduler = new Scheduler();
 
+  scheduleGaitActionServer = new ScheduleGaitActionServer(n, "march/gait/schedule", &scheduleGaitCallback, false);
+
   followJointTrajectoryAction = new actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction>(
       "/march/controller/trajectory/follow_joint_trajectory", true);
 
   ROS_DEBUG("Wait on joint trajectory action server");
-  bool isConnected = followJointTrajectoryAction->waitForServer(ros::Duration(10));
-  if (isConnected)
-  {
-    ROS_INFO("Connected to joint trajectory action server");
-  }
-  else
-  {
-    ROS_ERROR("Not connected to joint trajectory action server");
-  }
-
-  std::string controller_name;
-  n.getParam(ros::this_node::getName() + std::string("/controller_name"), controller_name);
-  trajectory_publisher = n.advertise<trajectory_msgs::JointTrajectory>("/" + controller_name + "/command", 1000);
+  followJointTrajectoryAction->waitForServer();
+  ROS_DEBUG("Connected to joint trajectory action server");
 
   dynamic_reconfigure::Server<march_gait_scheduler::SchedulerConfig> server;
   server.setCallback(boost::bind(&schedulerConfigCallback, _1, _2));
 
-  scheduleGaitActionServer = new ScheduleGaitActionServer(n, "march/gait/schedule", &scheduleGaitCallback, false);
   scheduleGaitActionServer->start();
 
   ros::spin();
 
+  delete scheduler;
+  delete followJointTrajectoryAction;
   return 0;
 }

--- a/march_gait_scheduler/src/GaitSchedulerNode.cpp
+++ b/march_gait_scheduler/src/GaitSchedulerNode.cpp
@@ -31,7 +31,7 @@ void doneCallback(const actionlib::SimpleClientGoalState& state,
   {
     scheduleGaitActionServer->setSucceeded();
     ROS_WARN("Gait trajectory execution DONE, this should only happen when GAIT_SUCCEEDED_OFFSET is 0");
-    ROS_INFO("Schedule gait action SUCCEEDED");
+    ROS_DEBUG("Schedule gait action SUCCEEDED");
   }
   else
   {

--- a/march_gait_scheduler/test/AcceptanceTest.cpp
+++ b/march_gait_scheduler/test/AcceptanceTest.cpp
@@ -52,7 +52,7 @@ protected:
       "/march/controller/trajectory/follow_joint_trajectory/goal", timeout_duration);
   ros::spinOnce();
 
-   EXPECT_EQ(0, callbackCounter.count);
+  EXPECT_EQ(0, callbackCounter.count);
 }
 
 TEST_F(AcceptanceTest, ScheduleOneGait)

--- a/march_gait_selection/src/march_gait_selection/GaitSelection.py
+++ b/march_gait_selection/src/march_gait_selection/GaitSelection.py
@@ -44,7 +44,7 @@ class GaitSelection(object):
             rospy.logwarn("No urdf found, cannot filter out unused joints. "
                           "The gait selection will publish gaits with all joints.")
         except socket.error:
-            rospy.loginfo("Could not connect to parameter server.")
+            rospy.logerr("Could not connect to parameter server.")
 
         rospy.loginfo("GaitSelection initialized with gait_directory %s/%s.", package, directory)
         rospy.logdebug("GaitSelection initialized with gait_version_map %s.", str(self.gait_version_map))

--- a/march_gait_selection/src/march_gait_selection/GaitSelectionNode.py
+++ b/march_gait_selection/src/march_gait_selection/GaitSelectionNode.py
@@ -25,7 +25,8 @@ class PerformGaitAction(object):
         self.action_server.start()
 
         self.schedule_gait_client = actionlib.SimpleActionClient("march/gait/schedule", GaitAction)
-        self.schedule_gait_client.wait_for_server()
+        while not rospy.is_shutdown() and not self.schedule_gait_client.wait_for_server(rospy.Duration(5.0)):
+            rospy.loginfo("Waiting for /march/gait/schedule to come up")
 
     def target_gait_callback(self, goal):
         rospy.logdebug("Trying to schedule subgait %s/%s", goal.name, goal.subgait_name)

--- a/march_launch/launch/march_headless.launch
+++ b/march_launch/launch/march_headless.launch
@@ -26,7 +26,7 @@
             pkg="rosbag"
             name="record"
             type="record"
-            output="screen"
+            output="log"
             args="-a -q -o $(arg bag_prefix)"
     />
 

--- a/march_launch/launch/march_headless.launch
+++ b/march_launch/launch/march_headless.launch
@@ -27,7 +27,7 @@
             name="record"
             type="record"
             output="screen"
-            args="-a -o $(arg bag_prefix)"
+            args="-a -q -o $(arg bag_prefix)"
     />
 
     <include file="$(find march_state_machine)/launch/march_state_machine.launch">

--- a/march_launch/launch/march_iv.launch
+++ b/march_launch/launch/march_iv.launch
@@ -5,7 +5,7 @@
             pkg="rosbag"
             name="record"
             type="record"
-            output="screen"
+            output="log"
             args="-a -q -o $(arg bag_prefix)"
     />
 

--- a/march_launch/launch/march_iv.launch
+++ b/march_launch/launch/march_iv.launch
@@ -6,7 +6,7 @@
             name="record"
             type="record"
             output="screen"
-            args="-a -o $(arg bag_prefix)"
+            args="-a -q -o $(arg bag_prefix)"
     />
 
     <include file="$(find march_state_machine)/launch/march_state_machine.launch"/>

--- a/march_rqt_launch_menu/src/march_rqt_launch_menu/launch_menu.py
+++ b/march_rqt_launch_menu/src/march_rqt_launch_menu/launch_menu.py
@@ -100,7 +100,7 @@ class LaunchMenuPlugin(Plugin):
 
     @staticmethod
     def publish_to_parameter_server(dictionary):
-        rospy.loginfo("Uploading the following launch_settings to the parameter server: " + str(dictionary))
+        rospy.logdebug("Uploading the following launch_settings to the parameter server: " + str(dictionary))
         for key, value in dictionary.iteritems():
             if key[0] == '~':
                 rospy.set_param(key[1:], value)

--- a/march_safety/src/InputDeviceSafety.cpp
+++ b/march_safety/src/InputDeviceSafety.cpp
@@ -12,7 +12,6 @@ InputDeviceSafety::InputDeviceSafety(ros::NodeHandle* n, SafetyHandler* safety_h
   this->safety_handler = safety_handler;
   this->time_last_alive = ros::Time(0);
   this->time_last_send_error = ros::Time(0);
-  ROS_INFO("subscribing to alive");
   this->subscriber_input_device_alive = n->subscribe<std_msgs::Time>(
       "/march/input_device/alive", 1000, &InputDeviceSafety::inputDeviceAliveCallback, this);
 }
@@ -22,7 +21,7 @@ void InputDeviceSafety::inputDeviceAliveCallback(const std_msgs::TimeConstPtr& m
   this->time_last_alive = msg->data;
   if (this->time_last_alive.toSec() == 0)
   {
-    ROS_INFO("Safety node started listing to the input device alive topic");
+    ROS_INFO("Safety node started listening to the input device alive topic");
   }
 }
 

--- a/march_safety/src/SafetyNode.cpp
+++ b/march_safety/src/SafetyNode.cpp
@@ -22,14 +22,6 @@ int main(int argc, char** argv)
   ros::NodeHandle n;
   ros::Rate rate(200);
 
-  // Create an error publisher to notify the system (state machine) if something is wrong
-  ros::Publisher error_publisher = n.advertise<march_shared_resources::Error>("/march/error", 1000);
-  ros::Publisher sound_publisher = n.advertise<march_shared_resources::Sound>("/march/sound/schedule", 1000);
-  ros::Publisher gait_instruction_publisher =
-      n.advertise<march_shared_resources::GaitInstruction>("/march/input_device/instruction", 1000);
-
-  SafetyHandler safetyHandler = SafetyHandler(&n, &error_publisher, &sound_publisher, &gait_instruction_publisher);
-
   std::vector<std::unique_ptr<SafetyType>> safety_list;
   int count = 0;
   while (!n.hasParam("/march/joint_names"))
@@ -45,6 +37,14 @@ int main(int argc, char** argv)
 
   std::vector<std::string> joint_names;
   n.getParam("/march/joint_names", joint_names);
+
+  // Create an error publisher to notify the system (state machine) if something is wrong
+  ros::Publisher error_publisher = n.advertise<march_shared_resources::Error>("/march/error", 1000);
+  ros::Publisher sound_publisher = n.advertise<march_shared_resources::Sound>("/march/sound/schedule", 1000);
+  ros::Publisher gait_instruction_publisher =
+      n.advertise<march_shared_resources::GaitInstruction>("/march/input_device/instruction", 1000);
+
+  SafetyHandler safety_handler = SafetyHandler(&n, &error_publisher, &sound_publisher, &gait_instruction_publisher);
 
   safety_list.push_back(std::unique_ptr<SafetyType>(new TemperatureSafety(&n, &safetyHandler, joint_names)));
   safety_list.push_back(std::unique_ptr<SafetyType>(new InputDeviceSafety(&n, &safetyHandler)));

--- a/march_safety/src/SafetyNode.cpp
+++ b/march_safety/src/SafetyNode.cpp
@@ -46,8 +46,8 @@ int main(int argc, char** argv)
 
   SafetyHandler safety_handler = SafetyHandler(&n, &error_publisher, &sound_publisher, &gait_instruction_publisher);
 
-  safety_list.push_back(std::unique_ptr<SafetyType>(new TemperatureSafety(&n, &safetyHandler, joint_names)));
-  safety_list.push_back(std::unique_ptr<SafetyType>(new InputDeviceSafety(&n, &safetyHandler)));
+  safety_list.push_back(std::unique_ptr<SafetyType>(new TemperatureSafety(&n, &safety_handler, joint_names)));
+  safety_list.push_back(std::unique_ptr<SafetyType>(new InputDeviceSafety(&n, &safety_handler)));
 
   while (ros::ok())
   {

--- a/march_sound_scheduler/src/SoundSchedulerNode.cpp
+++ b/march_sound_scheduler/src/SoundSchedulerNode.cpp
@@ -12,16 +12,17 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "march_sound_scheduler");
   ros::NodeHandle n;
 
-  ros::Publisher soundPub = n.advertise<sound_play::SoundRequest>("/robotsound", 0);
+  ros::Publisher sound_pub = n.advertise<sound_play::SoundRequest>("/robotsound", 0);
 
-  Scheduler scheduler;
-
-  ros::Subscriber soundSub = n.subscribe("/march/sound/schedule", 10, &Scheduler::scheduleMsg, &scheduler);
-  while (0 == soundPub.getNumSubscribers())
+  while (0 == sound_sub.getNumSubscribers())
   {
     ROS_DEBUG("Waiting on sound play topic");
     ros::Duration(0.1).sleep();
   }
+
+  Scheduler scheduler;
+
+  ros::Subscriber sound_sub = n.subscribe("/march/sound/schedule", 10, &Scheduler::scheduleMsg, &scheduler);
 
   ros::Rate rate(10);
   while (ros::ok())

--- a/march_sound_scheduler/src/SoundSchedulerNode.cpp
+++ b/march_sound_scheduler/src/SoundSchedulerNode.cpp
@@ -1,36 +1,34 @@
 // Copyright 2018 Project March.
 
-#include "ros/ros.h"
+#include <ros/ros.h>
 #include <actionlib/client/simple_action_client.h>
 #include <actionlib/server/simple_action_server.h>
 
-#include <march_shared_resources/Sound.h>
-#include <march_sound_scheduler/Scheduler.h>
-
-Scheduler* scheduler;
+#include "march_shared_resources/Sound.h"
+#include "march_sound_scheduler/Scheduler.h"
 
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "march_sound_scheduler");
   ros::NodeHandle n;
 
-  ros::Publisher pub_sound = n.advertise<sound_play::SoundRequest>("/robotsound", 0);
+  ros::Publisher soundPub = n.advertise<sound_play::SoundRequest>("/robotsound", 0);
 
-  scheduler = new Scheduler();
+  Scheduler scheduler;
 
-  ros::Subscriber soundSub = n.subscribe("/march/sound/schedule", 10, &Scheduler::scheduleMsg, scheduler);
-  while (0 == pub_sound.getNumSubscribers())
+  ros::Subscriber soundSub = n.subscribe("/march/sound/schedule", 10, &Scheduler::scheduleMsg, &scheduler);
+  while (0 == soundPub.getNumSubscribers())
   {
-    ROS_INFO("Waiting on sound play topic");
+    ROS_DEBUG("Waiting on sound play topic");
     ros::Duration(0.1).sleep();
   }
 
   ros::Rate rate(10);
   while (ros::ok())
   {
-    rate.sleep();
+    scheduler.spin();
     ros::spinOnce();
-    scheduler->spin();
+    rate.sleep();
   }
 
   return 0;

--- a/march_sound_scheduler/src/SoundSchedulerNode.cpp
+++ b/march_sound_scheduler/src/SoundSchedulerNode.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
 
   ros::Publisher sound_pub = n.advertise<sound_play::SoundRequest>("/robotsound", 0);
 
-  while (0 == sound_sub.getNumSubscribers())
+  while (0 == sound_pub.getNumSubscribers())
   {
     ROS_DEBUG("Waiting on sound play topic");
     ros::Duration(0.1).sleep();

--- a/march_state_machine/src/march_state_machine/states/LaunchState.py
+++ b/march_state_machine/src/march_state_machine/states/LaunchState.py
@@ -46,10 +46,10 @@ class LaunchState(smach.State):
     # @return The outcome of this state: `succeeded` or `failed`.
     def execute(self, userdata):
         if not self.should_execute_launch_file():
-            rospy.loginfo("Do not launch " + self.launch_file_name)
+            rospy.logdebug("Do not launch " + self.launch_file_name)
             return 'succeeded'
 
-        rospy.loginfo(
+        rospy.logdebug(
             "Launch " + self.package_name + " " + self.launch_file_name)
         return self.execute_launch_file()
 
@@ -106,5 +106,5 @@ class LaunchState(smach.State):
         if return_state is None:
             return 'succeeded'
         else:
-            rospy.loginfo("Process terminated")
+            rospy.logwarn("Process terminated")
             return 'failed'

--- a/march_state_machine/src/march_state_machine/states/WaitForRosControlState.py
+++ b/march_state_machine/src/march_state_machine/states/WaitForRosControlState.py
@@ -15,11 +15,11 @@ class WaitForRosControlState(smach.State):
     def execute(self, userdata):
         found = False
         end = rospy.get_rostime() + self.timeout
-        rospy.loginfo("trying to find controller manager")
-        rospy.wait_for_service('march/controller_manager/list_controllers', 5)
+        rospy.logdebug("trying to find controller manager")
         list_controllers = rospy.ServiceProxy(
             '/march/controller_manager/list_controllers', ListControllers)
-        rospy.loginfo("controller manager found")
+        list_controllers.wait_for_service()
+        rospy.logdebug("controller manager found")
 
         req = ListControllersRequest()
         while not found:
@@ -31,7 +31,7 @@ class WaitForRosControlState(smach.State):
                 for c in controller_list.controller:
                     if c.type == "effort_controllers/JointTrajectoryController" or \
                             c.type == "position_controllers/JointTrajectoryController":
-                        rospy.loginfo("found gazebo ros control")
+                        rospy.logdebug("found gazebo ros control")
                         found = True
                         return 'succeeded'
             except rospy.ServiceException, e:


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Partly closes PM-95

## Description
I rearranged the order of some action servers and topics subscriptions in order to make it easier to check when a node has started. This is important when all the nodes will be launched from the launch file instead of from the state machine. This way the state machine can check if the topics that are supposed to be available are available, so then it can transition to `HEALTHY`.

Furthermore, I downgraded some **info** logs to **debug** logs, since those were not necessary and only cluttering up the info level.

## Changes
* Rearrange safety node subscriptions
* Make `march_gait_scheduler` and `march_gait_selection` wait indefinitely for the action the server to be available, since there is no reason to continue if those are not available and many times they would continue and throw an error.
* Add `-q` parameter to `rosbag` to silence the `subscribed to ...` messages
* Remove the publisher in `march_gait_scheduler` to `/<controller_name>/command`, since the controller name parameter was not a valid one, so this did absolutely nothing.
* Add `delete` for allocated memory in `march_gait_scheduler`

<!-- Please don't forget to request for reviews -->
_**Leave your code better than you found it.**_
