### PR TITLE
Add installing python-lxml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ git:
 env:
   global:
     - ROS_REPO=ros
+    - ADDITIONAL_DEBS=python-lxml
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - BUILDER=colcon
     - CATKIN_LINT=pedantic


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->


## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
For some weird reason the script wouldn't install the `python-lxml` dependency, which is why the build failed in #382. This issue is not caused by that PR, but I think by a change in the `urdf-parser-py` package from [this commit](https://github.com/ros/urdf_parser_py/commit/87b2913d5b5cc06178569191e33b5fded2675b13#diff-34ae68f4adad56c25c5bc05dcb64794eR28). :thinking: 

Anyway I found a quickfix.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
* Added manual install of `python-lxml` package
<!-- Please don't forget to request for reviews -->
