### PR TITLE
Set test message timeout to 1 second

### DIFF
--- a/march_safety/test/TestTemperatureError.cpp
+++ b/march_safety/test/TestTemperatureError.cpp
@@ -31,7 +31,7 @@ TEST_F(TestTemperatureError, exceedSpecificThreshold)
   pub_joint1.publish(msg);
 
   // Wait to receive message
-  ros::Duration duration = ros::Duration(0.1);
+  ros::Duration duration = ros::Duration(1);
   ros::topic::waitForMessage<sensor_msgs::Temperature>("march/temperature/test_joint1", duration);
   ros::spinOnce();
 
@@ -59,7 +59,7 @@ TEST_F(TestTemperatureError, exceedDefaultThreshold)
   pub_joint3.publish(msg);
 
   // Wait to receive message
-  ros::Duration duration = ros::Duration(0.1);
+  ros::Duration duration = ros::Duration(1);
   ros::topic::waitForMessage<sensor_msgs::Temperature>("march/temperature/test_joint3", duration);
   ros::spinOnce();
 
@@ -93,7 +93,7 @@ TEST_F(TestTemperatureError, exceedDefaultThresholdMultipleTimes)
   }
 
   // Wait to receive message
-  ros::Duration duration = ros::Duration(0.1);
+  ros::Duration duration = ros::Duration(1);
   ros::topic::waitForMessage<sensor_msgs::Temperature>("march/temperature/test_joint3", duration);
   ros::spinOnce();
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Updated the timeout on 3 of the `march_safety` temperature tests. This was set to 0.1 seconds, but this would fail the test 50% of the time in the Travis, so I set it to 1 second, like all the other tests.
## Changes
* Change `TestTemperatureError` timeout from 0.1 to 1 second

<!-- Please don't forget to request for reviews -->
