### PR TITLE
Set header stamp to zero when gait should be scheduled now

### DIFF
--- a/march_gait_scheduler/include/march_gait_scheduler/scheduler.h
+++ b/march_gait_scheduler/include/march_gait_scheduler/scheduler.h
@@ -18,7 +18,7 @@ public:
   bool gaitDone = false;
   ros::Time getEndTimeCurrentGait();
   control_msgs::FollowJointTrajectoryGoal scheduleGait(const march_shared_resources::GaitGoal* gait_goal,
-                                                       ros::Duration offset);
+                                                       ros::Duration offset = ros::Duration(0, 0));
 
 private:
   ros::Time getStartTime(ros::Duration offset);

--- a/march_gait_scheduler/src/scheduler.cpp
+++ b/march_gait_scheduler/src/scheduler.cpp
@@ -4,7 +4,10 @@
 trajectory_msgs::JointTrajectory Scheduler::setStartTimeGait(trajectory_msgs::JointTrajectory trajectory,
                                                              ros::Time time)
 {
-  trajectory.header.stamp = time;
+  if (!time.isZero())
+  {
+    trajectory.header.stamp = time;
+  }
   return trajectory;
 }
 
@@ -26,9 +29,15 @@ ros::Time Scheduler::getStartTime(ros::Duration offset)
 
   if (current_time > end_current_gait)
   {
-    if (offset.toNSec() >= 0)
+    if (offset > ros::Duration(0, 0))
     {
       return current_time + offset;
+    }
+    else if (offset.isZero())
+    {
+      // Return zero time when gait can be scheduled right now,
+      // so that it doesn't drop the first trajectory point.
+      return ros::Time(0, 0);
     }
     else
     {
@@ -72,7 +81,7 @@ control_msgs::FollowJointTrajectoryGoal Scheduler::scheduleGait(const march_shar
   control_msgs::FollowJointTrajectoryGoal trajectory_msg;
   trajectory_msg.trajectory = trajectory;
 
-  this->start_last_gait_ = start_time;
+  this->start_last_gait_ = start_time.isZero() ? ros::Time::now() : start_time;
   this->last_gait_goal_ = gait_goal;
 
   return trajectory_msg;

--- a/march_gait_scheduler/test/ScheduleMultipleGaitsTest.cpp
+++ b/march_gait_scheduler/test/ScheduleMultipleGaitsTest.cpp
@@ -68,7 +68,7 @@ TEST_F(ScheduleMultipleGaitsTest, ScheduleTwoNoOffset)
 
   ros::Time secondStartTime = (current_time + gaitDuration);
 
-  ASSERT_NEAR(current_time.toSec(), trajectoryMsgSit.trajectory.header.stamp.toSec(), 0.1);
+  ASSERT_TRUE(trajectoryMsgSit.trajectory.header.stamp.isZero());
   ASSERT_NEAR(secondStartTime.toSec(), trajectoryMsgStand.trajectory.header.stamp.toSec(), 0.1);
 }
 
@@ -92,10 +92,10 @@ TEST_F(ScheduleMultipleGaitsTest, ScheduleTwoWithOffset)
   ros::Duration offset = ros::Duration().fromSec(3);
   control_msgs::FollowJointTrajectoryGoal trajectoryMsgStand = scheduler.scheduleGait(&gaitStandGoalConst, offset);
 
-  ros::Time secondStartTime = current_time + gaitDuration + offset;
+  ros::Time start_time = current_time + gaitDuration + offset;
 
-  ASSERT_NEAR(current_time.toSec(), trajectoryMsgSit.trajectory.header.stamp.toSec(), 0.1);
-  ASSERT_NEAR(secondStartTime.toSec(), trajectoryMsgStand.trajectory.header.stamp.toSec(), 0.1);
+  ASSERT_TRUE(trajectoryMsgSit.trajectory.header.stamp.isZero());
+  ASSERT_NEAR(start_time.toSec(), trajectoryMsgStand.trajectory.header.stamp.toSec(), 0.1);
 }
 
 TEST_F(ScheduleMultipleGaitsTest, ScheduleThreeNoOffset)
@@ -136,6 +136,6 @@ TEST_F(ScheduleMultipleGaitsTest, ScheduleSecondGaitInThePast)
   ros::Duration offset = ros::Duration().fromSec(-6);
   control_msgs::FollowJointTrajectoryGoal trajectoryMsgStand = scheduler.scheduleGait(&gaitStandGoalConst, offset);
 
-  ASSERT_NEAR(current_time.toSec(), trajectoryMsgSit.trajectory.header.stamp.toSec(), 0.1);
+  ASSERT_TRUE(trajectoryMsgSit.trajectory.header.stamp.isZero());
   ASSERT_NEAR(current_time.toSec(), trajectoryMsgStand.trajectory.header.stamp.toSec(), 0.1);
 }

--- a/march_gait_scheduler/test/ScheduleOneGaitTest.cpp
+++ b/march_gait_scheduler/test/ScheduleOneGaitTest.cpp
@@ -25,7 +25,6 @@ protected:
 TEST_F(ScheduleOneGaitTest, ScheduleNow)
 {
   ros::Time::init();
-  ros::Time current_time = ros::Time::now();
   march_shared_resources::GaitGoal gaitGoal;
   gaitGoal.current_subgait.trajectory = fake_sit_trajectory();
   gaitGoal.current_subgait.name = "sit";
@@ -36,7 +35,7 @@ TEST_F(ScheduleOneGaitTest, ScheduleNow)
   control_msgs::FollowJointTrajectoryGoal trajectoryMsg =
       scheduler.scheduleGait(&gaitGoalConst, ros::Duration().fromSec(0));
 
-  ASSERT_FLOAT_EQ(current_time.toSec(), trajectoryMsg.trajectory.header.stamp.toSec());
+  ASSERT_TRUE(trajectoryMsg.trajectory.header.stamp.isZero());
 }
 
 TEST_F(ScheduleOneGaitTest, ScheduledTrajectoryTheSameAsRequested)


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-81

## Description
This fixes the warning about dropping the first trajectory point. When a gait can be scheduled immediately it will no longer try to schedule it now, but rather not send a time and then the controller will schedule it now by default. The warning will no longer show. I found this fix when I found this PR: ros-controls/ros_controllers/pull/366

## Changes
* Set time to zero when no offset is given and the gait can be scheduled now
* Improve comparison of `offset`
* Fix tests

<!-- Please don't forget to request for reviews -->
