### PR TITLE
Move global start state to healthy state and add startup message

### DIFF
--- a/march_state_machine/src/march_state_machine/StateMachine.py
+++ b/march_state_machine/src/march_state_machine/StateMachine.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import sys
 import rospy
 import smach
@@ -8,14 +7,6 @@ from multiprocessing.pool import ThreadPool
 from march_state_machine import launch_sm, healthy_sm
 from march_state_machine.SafetyState import SafetyState
 from march_state_machine.states.EmptyState import EmptyState
-
-
-class Start(smach.State):
-    def __init__(self):
-        smach.State.__init__(self, outcomes=['succeeded'])
-
-    def execute(self, userdata):
-        return 'succeeded'
 
 
 def main():
@@ -45,8 +36,6 @@ def main():
 def create_sm():
     sm = smach.StateMachine(outcomes=['DONE'])
     with sm:
-        smach.StateMachine.add('START', Start(),
-                               transitions={'succeeded': 'LAUNCH'})
         smach.StateMachine.add('LAUNCH', launch_sm.create(),
                                transitions={'succeeded': 'HEALTHY', 'failed': 'SHUTDOWN'})
 

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+import rospy
 import smach
 
 from march_state_machine import walk_sm
@@ -21,12 +21,22 @@ from march_state_machine.states.IdleState import IdleState
 from march_state_machine.states.GaitState import GaitState
 
 
+class HealthyStart(smach.State):
+    def __init__(self):
+        smach.State.__init__(self, outcomes=['succeeded'])
+
+    def execute(self, userdata):
+        rospy.loginfo('March is fully operational')
+        return 'succeeded'
+
+
 def create():
     sm_healthy = smach.StateMachine(outcomes=['succeeded', 'failed'])
     # Open the container
     with sm_healthy:
         # Add states to the container
-
+        smach.StateMachine.add('START', HealthyStart(),
+                               transitions={'succeeded': 'UNKNOWN'})
         smach.StateMachine.add('UNKNOWN', IdleState(outcomes=['home_sit', 'home_stand', 'failed', 'preempted']),
                                transitions={
                                    'home_sit': 'HOME SIT',


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-80

## Description
Adds a message when the exoskeleton is operational and ready to walk :walking_man: 
I figured that this way it will be useful when we start using the error state and the sm has to return to `HEALTHY` again.

## Changes
* Moved global `START` state to `HEALTHY` state
* Added message

<!-- Please don't forget to request for reviews -->
