### PR TITLE
Add rate of 2Hz to requesting controllers

### DIFF
--- a/march_state_machine/src/march_state_machine/states/WaitForRosControlState.py
+++ b/march_state_machine/src/march_state_machine/states/WaitForRosControlState.py
@@ -19,6 +19,7 @@ class WaitForRosControlState(smach.State):
         rospy.logdebug('controller manager found')
 
         req = ListControllersRequest()
+        rate = rospy.Rate(2)
         while True:
             if rospy.get_rostime() > end:
                 rospy.logwarn('unable to find a JointTrajectoryController')
@@ -33,3 +34,4 @@ class WaitForRosControlState(smach.State):
             except rospy.ServiceException as e:
                 rospy.logwarn('Service call failed: %s' % e)
                 return 'failed'
+            rate.sleep()


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-145

## Description
The state machine would spam the controller manager as fast as it could with requests to list the controllers. This would for unknown reasons cause the hardware interface to not launch correctly. I added a rate of 2Hz, tested it and now it will launch successfully.

## Changes
* Add 2Hz rate

<!-- Please don't forget to request for reviews -->
