### PR TITLE
Change home gaits to state machines

### DIFF
--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -5,7 +5,6 @@ from std_srvs.srv import Empty, EmptyRequest
 from .gaits import ramp_down_sm
 from .state_machines.step_state_machine import StepStateMachine
 from .state_machines.walk_state_machine import WalkStateMachine
-from .states.gait_state import GaitState
 from .states.idle_state import IdleState
 
 
@@ -33,11 +32,11 @@ def create():
                                transitions={'home_sit': 'HOME SIT', 'home_stand': 'HOME STAND'})
 
         # Movement states
-        smach.StateMachine.add('HOME SIT', GaitState('home', 'home_sit'),
-                               transitions={'succeeded': 'SITTING', 'aborted': 'UNKNOWN'})
+        smach.StateMachine.add('HOME SIT', StepStateMachine('home', ['home_sit']),
+                               transitions={'succeeded': 'SITTING', 'failed': 'UNKNOWN'})
 
-        smach.StateMachine.add('HOME STAND', GaitState('home', 'home_stand'),
-                               transitions={'succeeded': 'STANDING', 'aborted': 'UNKNOWN'})
+        smach.StateMachine.add('HOME STAND', StepStateMachine('home', ['home_stand']),
+                               transitions={'succeeded': 'STANDING', 'failed': 'UNKNOWN'})
 
         smach.StateMachine.add('GAIT WALK', WalkStateMachine('walk'),
                                transitions={'succeeded': 'STANDING', 'failed': 'UNKNOWN'})


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-227

## Description
the home gaits would not send a finished message on home gaits. So I changed the home gaits to a `GaitStateMachine` so they would send a finished message.

## Changes
* Change `home_sit` and `home_stand` gaits to state machines

<!-- Please don't forget to request for reviews -->
