### PR TITLE
Add gait_directory arguments to high level launch files

### DIFF
--- a/march_launch/launch/march.launch
+++ b/march_launch/launch/march.launch
@@ -10,6 +10,8 @@
     <arg name="unpause" default="true" doc="Unpause simulation when controller starts."/>
     <arg name="fixed" default="true" doc="Fixes the exoskeleton in the world"/>
 
+    <arg name="gait_directory" default="training-v" doc="Gait files directory to use"/>
+
     <arg name="rosbag" default="true" doc="Enables rosbag record node."/>
     <arg name="bag_prefix" default="log" doc="Prefix of the bag file. Only used if rosbag is true."/>
 
@@ -34,7 +36,9 @@
 
         <include file="$(find march_sound_scheduler)/launch/march_sound_scheduler.launch"/>
 
-        <include file="$(find march_gait_selection)/launch/march_gait_selection.launch"/>
+        <include file="$(find march_gait_selection)/launch/march_gait_selection.launch">
+            <arg name="gait_directory" value="$(arg gait_directory)"/>
+        </include>
 
         <node name="gait_scheduler_node" pkg="march_gait_scheduler" type="march_gait_scheduler_node" output="screen" required="true"/>
 

--- a/march_launch/launch/march_headless.launch
+++ b/march_launch/launch/march_headless.launch
@@ -1,6 +1,7 @@
 <launch>
     <arg name="hardware_interface" default="true" doc="Launches the hardware_interface."/>
     <arg name="wireless" default="false" doc="Enables wireless connection to the input device."/>
+    <arg name="gait_directory" default="training-v" doc="Gait files directory to use"/>
 
     <include file="$(find march_launch)/launch/march.launch" pass_all_args="true">
         <arg name="configuration" value="exoskeleton"/>

--- a/march_launch/launch/march_simulation.launch
+++ b/march_launch/launch/march_simulation.launch
@@ -5,9 +5,9 @@
     <arg name="rosbag" default="false" doc="Enables rosbag record node."/>
     <arg name="unpause" default="$(eval not gazebo_ui)" doc="Unpause simulation when controller starts."/>
     <arg name="fixed" default="true" doc="Fixes the exoskeleton in the world"/>
+    <arg name="gait_directory" default="training-v" doc="Gait files directory to use"/>
 
     <include file="$(find march_launch)/launch/march.launch" pass_all_args="true">
         <arg name="configuration" value="simulation"/>
-        <arg name="unpause" value="$(arg unpause)"/>
     </include>
 </launch>


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->


## Description
I was testing project-march/gait-files#131 and figured it would be useful to add an argument for choosing the gait directory in the high level launch files, so simulation, headless and normal. You can now choose the directory with:

    roslaunch march_launch march_simulation.launch gait_directory:=<directory>

## Changes
* Added `gait_directory` argument to `march_headless`, `march` and `march_simulation`
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

<!-- Please don't forget to request for reviews -->
