### PR TITLE
Add launch argument for input device

### DIFF
--- a/march_launch/launch/march.launch
+++ b/march_launch/launch/march.launch
@@ -2,13 +2,17 @@
     <arg name="configuration" default="exoskeleton" doc="Configuration on launching the 'simulation' or 'exoskeleton'."/>
     <arg name="headless" default="false" doc="Launches no GUI when true."/>
     <arg name="hardware_interface" default="true" doc="Launches the hardware interface when config is 'exoskeleton."/>
+
     <arg name="rviz" default="false" doc="Launches RViz."/>
     <arg name="state_machine_viewer" default="false" doc="Launches the SMACH viewer."/>
     <arg name="rqt_input" default="true" doc="Launches the march rqt input device."/>
     <arg name="gazebo_ui" default="false" doc="Launches the Gazebo UI."/>
-    <arg name="wireless" default="false" doc="Enables wireless connection to the input device."/>
+
     <arg name="unpause" default="true" doc="Unpause simulation when controller starts."/>
     <arg name="fixed" default="true" doc="Fixes the exoskeleton in the world"/>
+
+    <arg name="input-device" default="false" doc="Launches ros serial node to connect with input device."/>
+    <arg name="wireless" default="false" doc="Enables wireless connection to the input device."/>
 
     <arg name="gait_directory" default="training-v" doc="Gait files directory to use"/>
 
@@ -48,9 +52,6 @@
     </group>
 
     <group if="$(eval configuration == 'exoskeleton')">
-        <include file="$(find march_launch)/launch/serial_connection.launch">
-            <arg name="wireless" value="$(arg wireless)"/>
-        </include>
         <include file="$(find march_hardware_interface)/launch/hardware.launch" if="$(arg hardware_interface)">
             <arg name="robot" value="march4"/>
         </include>
@@ -62,4 +63,8 @@
             <arg name="fixed" value="$(arg fixed)"/>
         </include>
     </group>
+
+    <include file="$(find march_launch)/launch/serial_connection.launch" if="$(arg input-device)">
+        <arg name="wireless" value="$(arg wireless)"/>
+    </include>
 </launch>

--- a/march_launch/launch/march_headless.launch
+++ b/march_launch/launch/march_headless.launch
@@ -2,6 +2,7 @@
     <arg name="hardware_interface" default="true" doc="Launches the hardware_interface."/>
     <arg name="wireless" default="false" doc="Enables wireless connection to the input device."/>
     <arg name="gait_directory" default="training-v" doc="Gait files directory to use"/>
+    <arg name="input-device" default="true" doc="Launches ros serial node to connect with input device."/>
 
     <include file="$(find march_launch)/launch/march.launch" pass_all_args="true">
         <arg name="configuration" value="exoskeleton"/>

--- a/march_launch/launch/march_simulation.launch
+++ b/march_launch/launch/march_simulation.launch
@@ -6,6 +6,7 @@
     <arg name="unpause" default="$(eval not gazebo_ui)" doc="Unpause simulation when controller starts."/>
     <arg name="fixed" default="true" doc="Fixes the exoskeleton in the world"/>
     <arg name="gait_directory" default="training-v" doc="Gait files directory to use"/>
+    <arg name="input-device" default="false" doc="Launches ros serial node to connect with input device."/>
 
     <include file="$(find march_launch)/launch/march.launch" pass_all_args="true">
         <arg name="configuration" value="simulation"/>


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

## Description
I have added a input device argument to the launch files to make it easier to launch the input device for simulation and changed it to not launch on default. Except for `march_headless.launch`.
## Changes
* Add `input-device` argument

<!-- Please don't forget to request for reviews -->
