### PR TITLE
Feature/add side step off tilted path to state machine

### DIFF
--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
@@ -1,0 +1,21 @@
+import smach
+
+from march_state_machine.state_machines.step_state_machine import StepStateMachine
+from march_state_machine.states.idle_state import IdleState
+
+
+def create():
+    sm_tilted_path_sideways_end = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    with sm_tilted_path_sideways_end:
+        smach.StateMachine.add('GAIT TP FIRST END', StepStateMachine('tilted_path_first_end',
+                                                                     subgaits=['left_open', 'right_close']),
+                               transitions={'succeeded': 'STANDING TP SIDEWAYS END', 'failed': 'failed'})
+
+        smach.StateMachine.add('STANDING TP SIDEWAYS END', IdleState(outcomes=['gait_tilted_path_second_end',
+                                                                     'preempted']),
+                               transitions={'gait_tilted_path_second_end': 'GAIT TP SECOND END'})
+
+        smach.StateMachine.add('GAIT TP SECOND END', StepStateMachine('tilted_path_second_end',
+                                                                      subgaits=['left_open', 'right_close']))
+
+    return sm_tilted_path_sideways_end

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_sm.py
@@ -7,15 +7,15 @@ from march_state_machine.states.idle_state import IdleState
 def create():
     sm_tilted_path_sideways = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
     with sm_tilted_path_sideways:
-        smach.StateMachine.add('GAIT TP STRAIGHT FIRST', StepStateMachine('tilted_path_first_start',
-                                                                          subgaits=['left_open', 'right_close']),
+        smach.StateMachine.add('GAIT TP FIRST START', StepStateMachine('tilted_path_first_start',
+                                                                       subgaits=['left_open', 'right_close']),
                                transitions={'succeeded': 'STANDING TP SIDEWAYS', 'failed': 'failed'})
 
         smach.StateMachine.add('STANDING TP SIDEWAYS', IdleState(outcomes=['gait_tilted_path_second_start',
                                                                            'preempted']),
-                               transitions={'gait_tilted_path_second_start': 'GAIT TP STRAIGHT SECOND'})
+                               transitions={'gait_tilted_path_second_start': 'GAIT TP SECOND START'})
 
-        smach.StateMachine.add('GAIT TP STRAIGHT SECOND', StepStateMachine('tilted_path_second_start',
-                                                                           subgaits=['left_open', 'right_close']))
+        smach.StateMachine.add('GAIT TP SECOND START', StepStateMachine('tilted_path_second_start',
+                                                                        subgaits=['left_open', 'right_close']))
 
     return sm_tilted_path_sideways

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
@@ -5,17 +5,17 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_tilted_path_sideways = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
-    with sm_tilted_path_sideways:
+    sm_tilted_path_sideways_start = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    with sm_tilted_path_sideways_start:
         smach.StateMachine.add('GAIT TP FIRST START', StepStateMachine('tilted_path_first_start',
                                                                        subgaits=['left_open', 'right_close']),
-                               transitions={'succeeded': 'STANDING TP SIDEWAYS', 'failed': 'failed'})
+                               transitions={'succeeded': 'STANDING TP SIDEWAYS START', 'failed': 'failed'})
 
-        smach.StateMachine.add('STANDING TP SIDEWAYS', IdleState(outcomes=['gait_tilted_path_second_start',
-                                                                           'preempted']),
+        smach.StateMachine.add('STANDING TP SIDEWAYS START', IdleState(outcomes=['gait_tilted_path_second_start',
+                                                                       'preempted']),
                                transitions={'gait_tilted_path_second_start': 'GAIT TP SECOND START'})
 
         smach.StateMachine.add('GAIT TP SECOND START', StepStateMachine('tilted_path_second_start',
                                                                         subgaits=['left_open', 'right_close']))
 
-    return sm_tilted_path_sideways
+    return sm_tilted_path_sideways_start

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -5,7 +5,8 @@ from std_srvs.srv import Empty, EmptyRequest
 from march_shared_resources.srv import PossibleGaits
 
 from .gaits import ramp_down_sm
-from .gaits import tilted_path_sideways_sm
+from .gaits import tilted_path_sideways_end_sm
+from .gaits import tilted_path_sideways_start_sm
 from .state_machines.slope_state_machine import SlopeStateMachine
 from .state_machines.step_state_machine import StepStateMachine
 from .state_machines.walk_state_machine import WalkStateMachine
@@ -85,7 +86,8 @@ class HealthyStateMachine(smach.StateMachine):
                                         subgaits=['left_open', 'right_close']),
                        'STANDING')
 
-        self.add_state('GAIT TP SIDEWAYS', tilted_path_sideways_sm.create(), 'STANDING')
+        self.add_state('GAIT TP SIDEWAYS START', tilted_path_sideways_start_sm.create(), 'STANDING')
+        self.add_state('GAIT TP SIDEWAYS END', tilted_path_sideways_end_sm.create(), 'STANDING')
 
         self.add('SITTING', IdleState(outcomes=['gait_stand', 'preempted']),
                  transitions={'gait_stand': 'GAIT STAND'})
@@ -100,6 +102,7 @@ class HealthyStateMachine(smach.StateMachine):
                                                  'gait_tilted_path_straight_start_right',
                                                  'gait_tilted_path_straight_start_left',
                                                  'gait_tilted_path_first_start',
+                                                 'gait_tilted_path_first_end',
                                                  'preempted']),
                  transitions={'gait_sit': 'GAIT SIT', 'gait_walk': 'GAIT WALK',
                               'gait_single_step_small': 'GAIT SINGLE STEP SMALL',
@@ -118,7 +121,8 @@ class HealthyStateMachine(smach.StateMachine):
                               'gait_ramp_door_slope_down': 'GAIT RD RAMP DOWN',
                               'gait_tilted_path_straight_start_right': 'GAIT TP STRAIGHT START RIGHT',
                               'gait_tilted_path_straight_start_left': 'GAIT TP STRAIGHT START LEFT',
-                              'gait_tilted_path_first_start': 'GAIT TP SIDEWAYS'})
+                              'gait_tilted_path_first_start': 'GAIT TP SIDEWAYS START',
+                              'gait_tilted_path_first_end': 'GAIT TP SIDEWAYS END'})
         self.close()
 
     def add_state(self, label, state, succeeded):


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
I added the ending steps off the tilted path (sideways) to the state machine. Therefore, I created a new state machine called `tilted_path_sideways_end_sm`. This because after the first ending step you end not in the STANDING IDLE state, but in the IDLE state TP SIDEWAYS END, so only the second ending step can be executed from that state. Furthermore, I changed the name of `tilted_path_sideways_sm` into `tilted_path_sideways_start_sm` to make clear distinction between stepping on or off the tilted path.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
New state machine:
`tilted_path_sideways_end_sm`

Renamed state machine:
`tilted_path_sideways_start_sm`

Added ending steps to `healthy_sm`
<!-- Please don't forget to request for reviews -->
