### PR TITLE
Add new Tilted Path gaits.

### DIFF
--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_straight_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_straight_sm.py
@@ -1,0 +1,27 @@
+import smach
+
+from march_state_machine.state_machines.step_state_machine import StepStateMachine
+from march_state_machine.states.idle_state import IdleState
+
+
+def create():
+    sm_tilted_path_straight = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    with sm_tilted_path_straight:
+        smach.StateMachine.add('GAIT TP STRAIGHT START', StepStateMachine('tilted_path_straight_start',
+                               subgaits=['right_open', 'left_close']),
+                               transitions={'succeeded': 'STANDING TP STRAIGHT', 'failed': 'failed'})
+
+        smach.StateMachine.add('GAIT TP SINGLE STEP', StepStateMachine('tilted_path_single_step',
+                               subgaits=['right_open', 'left_close']),
+                               transitions={'succeeded': 'STANDING TP STRAIGHT', 'failed': 'failed'})
+
+        smach.StateMachine.add('STANDING TP STRAIGHT', IdleState(outcomes=['gait_tilted_path_single_step',
+                                                                           'gait_tilted_path_straight_end',
+                                                                           'preempted']),
+                               transitions={'gait_tilted_path_single_step': 'GAIT TP SINGLE STEP',
+                                            'gait_tilted_path_straight_end': 'GAIT TP STRAIGHT END'})
+
+        smach.StateMachine.add('GAIT TP STRAIGHT END', StepStateMachine('tilted_path_straight_end',
+                                                                        subgaits=['left_open', 'right_close']))
+
+    return sm_tilted_path_straight

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -7,6 +7,7 @@ from march_shared_resources.srv import PossibleGaits
 from .gaits import slope_down_sm
 from .gaits import tilted_path_sideways_end_sm
 from .gaits import tilted_path_sideways_start_sm
+from .gaits import tilted_path_straight_sm
 from .state_machines.slope_state_machine import SlopeStateMachine
 from .state_machines.step_state_machine import StepStateMachine
 from .state_machines.walk_state_machine import WalkStateMachine
@@ -85,11 +86,7 @@ class HealthyStateMachine(smach.StateMachine):
         self.add_state('GAIT RD SLOPE DOWN', slope_down_sm.create(), 'STANDING')
 
         # TP stands for Tilted Path
-        self.add_state('GAIT TP STRAIGHT START RIGHT', StepStateMachine('tilted_path_straight_start_right'), 'STANDING')
-        self.add_state('GAIT TP STRAIGHT START LEFT',
-                       StepStateMachine('tilted_path_straight_start_left',
-                                        subgaits=['left_open', 'right_close']),
-                       'STANDING')
+        self.add_state('GAIT TP STRAIGHT', tilted_path_straight_sm.create(), 'STANDING')
 
         self.add_state('GAIT TP SIDEWAYS START', tilted_path_sideways_start_sm.create(), 'STANDING')
         self.add_state('GAIT TP SIDEWAYS END', tilted_path_sideways_end_sm.create(), 'STANDING')
@@ -107,8 +104,7 @@ class HealthyStateMachine(smach.StateMachine):
                                                  'gait_rough_terrain_second_middle_step',
                                                  'gait_rough_terrain_third_middle_step',
                                                  'gait_ramp_door_slope_up', 'gait_ramp_door_slope_down',
-                                                 'gait_tilted_path_straight_start_right',
-                                                 'gait_tilted_path_straight_start_left',
+                                                 'gait_tilted_path_straight_start',
                                                  'gait_tilted_path_first_start',
                                                  'gait_tilted_path_first_end',
                                                  'preempted']),
@@ -130,8 +126,7 @@ class HealthyStateMachine(smach.StateMachine):
                               'gait_rough_terrain_third_middle_step': 'GAIT RT THIRD MIDDLE STEP',
                               'gait_ramp_door_slope_up': 'GAIT RD SLOPE UP',
                               'gait_ramp_door_slope_down': 'GAIT RD SLOPE DOWN',
-                              'gait_tilted_path_straight_start_right': 'GAIT TP STRAIGHT START RIGHT',
-                              'gait_tilted_path_straight_start_left': 'GAIT TP STRAIGHT START LEFT',
+                              'gait_tilted_path_straight_start': 'GAIT TP STRAIGHT',
                               'gait_tilted_path_first_start': 'GAIT TP SIDEWAYS START',
                               'gait_tilted_path_first_end': 'GAIT TP SIDEWAYS END'})
         self.close()


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
--> We added the new Tilted Path gaits we made to the state machine. There are three new gaits, which are meant for walking straight over the obstacle.
The first gait is for stepping on the obstacle, and you end with the left leg a little bent. Then we have single steps for the grass part of the obstacle, that also have the left leg a little bent thoughout. Lastly, you step off the obstacle with another step. In between all these states, we have created a new idle state (because of the left leg). So when you have stepped on the obstacle, you can only select the Tilted Path single step or the Tilted Path ending step. This is why we created a new state machine for this obstacle.

This gait is a replacement for the gaits 'tilted_path_straight_start_left' and 'tilted_path_straight_start_right', so we removed those from the state machine. The Tilted Path gaits for the sideways version are still in the state machine, as we still might want to use those.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
--> Added three new gaits for the Tilted Path in the state machine and removed two old gaits.

<!-- Please don't forget to request for reviews -->
