### PR TITLE
add version to subgait.msg

### DIFF
--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -163,7 +163,7 @@ class Subgait(object):
         subgait_msg.trajectory = self._to_joint_trajectory_msg()
         subgait_msg.setpoints = self._to_setpoints_msg()
         subgait_msg.description = str(self.description)
-        subgait_msg.version = str(self.version)
+        subgait_msg.version = self.version
         subgait_msg.duration = rospy.Duration.from_sec(self.duration)
 
         return subgait_msg

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -163,6 +163,7 @@ class Subgait(object):
         subgait_msg.trajectory = self._to_joint_trajectory_msg()
         subgait_msg.setpoints = self._to_setpoints_msg()
         subgait_msg.description = str(self.description)
+        subgait_msg.version = str(self.version)
         subgait_msg.duration = rospy.Duration.from_sec(self.duration)
 
         return subgait_msg

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -162,7 +162,7 @@ class Subgait(object):
         subgait_msg.gait_type = self.gait_type
         subgait_msg.trajectory = self._to_joint_trajectory_msg()
         subgait_msg.setpoints = self._to_setpoints_msg()
-        subgait_msg.description = str(self.description)
+        subgait_msg.description = self.description
         subgait_msg.version = self.version
         subgait_msg.duration = rospy.Duration.from_sec(self.duration)
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-273

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
There was a little bug in the subgait.py, where the version in the msg was not set, when a msg was create from the class. Therefore the version is not in the gait files and also not in the messages on /march/gait/schedule/gait 

The version is now also read from the filename and not from the file. I think it is better to also read the version from the gait files, but these are all empty strings now.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
The version is also set in the to_subgait_msg method in the subgait class. 
<!-- Please don't forget to request for reviews -->
