### PR TITLE
Fix all compiler warnings and turn them into errors

### DIFF
--- a/march_gait_scheduler/CMakeLists.txt
+++ b/march_gait_scheduler/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_gait_scheduler)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     actionlib

--- a/march_safety/CMakeLists.txt
+++ b/march_safety/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_safety)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     march_shared_resources

--- a/march_safety/test/connection_lost_test.cpp
+++ b/march_safety/test/connection_lost_test.cpp
@@ -18,9 +18,9 @@ TEST_F(TestConnectionLost, connectionLost)
   ros::Time::init();
   ros::NodeHandle nh;
 
-  int input_device_connection_timeout;
+  double input_device_connection_timeout;
   nh.getParam("/march_safety_node/input_device_connection_timeout", input_device_connection_timeout);
-  int send_errors_interval;
+  double send_errors_interval;
   nh.getParam("/march_safety_node/send_errors_interval", send_errors_interval);
 
   ros::Publisher pub_alive = nh.advertise<std_msgs::Time>("march/input_device/alive", 0);
@@ -31,18 +31,18 @@ TEST_F(TestConnectionLost, connectionLost)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_alive.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, pub_alive.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   std_msgs::Time timeMessage;
   timeMessage.data = ros::Time::now();
   pub_alive.publish(timeMessage);
   ros::spinOnce();
-  int sleep_ms = send_errors_interval * 0.9 + input_device_connection_timeout;
+  double sleep_ms = send_errors_interval * 0.9 + input_device_connection_timeout;
   ros::Duration(sleep_ms / 1000).sleep();
   ros::spinOnce();
 
-  EXPECT_EQ(1, errorCounter.count);
+  EXPECT_EQ(1u, errorCounter.count);
 }
 
 /**

--- a/march_safety/test/connection_never_started_test.cpp
+++ b/march_safety/test/connection_never_started_test.cpp
@@ -20,16 +20,16 @@ TEST_F(TestConnectionNeverStarted, connectionNeverStarted)
   ErrorCounter errorCounter;
   ros::Subscriber sub = nh.subscribe("march/error", 0, &ErrorCounter::cb, &errorCounter);
 
-  while (0 == sub.getNumPublishers())
+  while (0u == sub.getNumPublishers())
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   ros::spinOnce();
   ros::Duration(0.5).sleep();
   ros::spinOnce();
-  EXPECT_EQ(0, errorCounter.count);
+  EXPECT_EQ(0u, errorCounter.count);
 }
 
 /**

--- a/march_safety/test/connection_not_lost_test.cpp
+++ b/march_safety/test/connection_not_lost_test.cpp
@@ -17,7 +17,7 @@ TEST_F(TestConnectionNotLost, connectionNotLost)
 {
   ros::Time::init();
   ros::NodeHandle nh;
-  int send_errors_interval;
+  double send_errors_interval;
   nh.getParam("/march_safety_node/send_errors_interval", send_errors_interval);
   ros::Publisher pub_alive = nh.advertise<std_msgs::Time>("march/input_device/alive", 0);
   ErrorCounter errorCounter;
@@ -27,8 +27,8 @@ TEST_F(TestConnectionNotLost, connectionNotLost)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_alive.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, pub_alive.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   std_msgs::Time timeMessage;
   timeMessage.data = ros::Time::now();
@@ -36,7 +36,7 @@ TEST_F(TestConnectionNotLost, connectionNotLost)
   ros::spinOnce();
   ros::Duration(send_errors_interval / 2 / 1000).sleep();
   ros::spinOnce();
-  EXPECT_EQ(0, errorCounter.count);
+  EXPECT_EQ(0u, errorCounter.count);
 }
 
 /**

--- a/march_safety/test/no_temperature_error_test.cpp
+++ b/march_safety/test/no_temperature_error_test.cpp
@@ -16,8 +16,8 @@ TEST(TestNoTemperatureError, belowSpecificThreshold)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_joint1.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, pub_joint1.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   sensor_msgs::Temperature msg;
   int temperature;
@@ -33,7 +33,7 @@ TEST(TestNoTemperatureError, belowSpecificThreshold)
   ros::topic::waitForMessage<sensor_msgs::Temperature>("march/temperature/test_joint1", duration);
   ros::spinOnce();
 
-  EXPECT_EQ(0, errorCounter.count);
+  EXPECT_EQ(0u, errorCounter.count);
 }
 
 /**
@@ -51,8 +51,8 @@ TEST(TestNoTemperatureError, belowSpecificThreshold2)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_joint2.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, pub_joint2.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   sensor_msgs::Temperature msg;
   int temperature;
@@ -68,7 +68,7 @@ TEST(TestNoTemperatureError, belowSpecificThreshold2)
   ros::topic::waitForMessage<sensor_msgs::Temperature>("march/temperature/test_joint2", duration);
   ros::spinOnce();
 
-  EXPECT_EQ(0, errorCounter.count);
+  EXPECT_EQ(0u, errorCounter.count);
 }
 
 TEST(TestNoTemperatureError, belowDefaultThreshold)
@@ -82,8 +82,8 @@ TEST(TestNoTemperatureError, belowDefaultThreshold)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_joint3.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, pub_joint3.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   sensor_msgs::Temperature msg;
   int temperature;
@@ -99,5 +99,5 @@ TEST(TestNoTemperatureError, belowDefaultThreshold)
   ros::topic::waitForMessage<sensor_msgs::Temperature>("march/temperature/test_joint3", duration);
   ros::spinOnce();
 
-  EXPECT_EQ(0, errorCounter.count);
+  EXPECT_EQ(0u, errorCounter.count);
 }

--- a/march_safety/test/temperature_error_test.cpp
+++ b/march_safety/test/temperature_error_test.cpp
@@ -16,8 +16,8 @@ TEST(TestTemperatureError, exceedDefaultThreshold)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_joint3.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, pub_joint3.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   sensor_msgs::Temperature msg;
   int temperature;
@@ -33,7 +33,7 @@ TEST(TestTemperatureError, exceedDefaultThreshold)
   ros::topic::waitForMessage<sensor_msgs::Temperature>("march/temperature/test_joint3", duration);
   ros::spinOnce();
 
-  EXPECT_EQ(1, errorCounter.count);
+  EXPECT_EQ(1u, errorCounter.count);
 }
 
 TEST(TestTemperatureError, exceedDefaultThresholdMultipleTimes)
@@ -48,16 +48,16 @@ TEST(TestTemperatureError, exceedDefaultThresholdMultipleTimes)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_joint3.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
+  EXPECT_EQ(1u, pub_joint3.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
 
   sensor_msgs::Temperature msg;
   int temperature;
   nh.getParam("/march_safety_node/default_temperature_threshold", temperature);
   msg.temperature = temperature + 1;
 
-  int times = 5;
-  for (int i = 0; i < times; i++)
+  size_t times = 5;
+  for (size_t i = 0; i < times; i++)
   {
     pub_joint3.publish(msg);
   }

--- a/march_safety/test/temperature_parameterized_test.cpp
+++ b/march_safety/test/temperature_parameterized_test.cpp
@@ -47,9 +47,9 @@ TEST_P(TestTemperatureParameterized, valuesAroundThreshold)
   {
     ros::Duration(0.1).sleep();
   }
-  EXPECT_EQ(1, pub_joint1.getNumSubscribers());
-  EXPECT_EQ(1, sub.getNumPublishers());
-  EXPECT_EQ(0, errorCounter.count);
+  EXPECT_EQ(1u, pub_joint1.getNumSubscribers());
+  EXPECT_EQ(1u, sub.getNumPublishers());
+  EXPECT_EQ(0u, errorCounter.count);
 
   sensor_msgs::Temperature msg;
   msg.temperature = temperature;


### PR DESCRIPTION
## Description
Cleaned up those compiler warnings and turn them into errors :no_entry: 

## Changes
* Fixed compiler warnings
* Added `-Werror` to turn warnings into errors
* Added `-std=c++14` to compile with c++14 standard
<!-- Please don't forget to request for reviews -->
