### PR TITLE
decrease max effort

### DIFF
--- a/march_description/urdf/march4.xacro
+++ b/march_description/urdf/march4.xacro
@@ -19,7 +19,8 @@
         </gazebo>
     </xacro:if>
 
-    <xacro:arg name="max_effort_rotary" default="20475" /> <!-- = 25 A -->
+    <xacro:arg name="max_effort_rotary" default="16000.0" />
+    <!-- Lowered based because of shortcircuit errors, theoretical max 20475 = 25 A -->
     <xacro:arg name="max_effort_linear" default="22932.0" />  <!-- = 28 A -->
     <xacro:property name="max_effort_rotary" value="$(arg max_effort_rotary)" />
     <xacro:property name="max_effort_linear" value="$(arg max_effort_linear)" />

--- a/march_description/urdf/march4.xacro
+++ b/march_description/urdf/march4.xacro
@@ -19,8 +19,8 @@
         </gazebo>
     </xacro:if>
 
-    <xacro:arg name="max_effort_rotary" default="16000.0" />
     <!-- Lowered based because of shortcircuit errors, theoretical max 20475 = 25 A -->
+    <xacro:arg name="max_effort_rotary" default="16000.0" />
     <xacro:arg name="max_effort_linear" default="22932.0" />  <!-- = 28 A -->
     <xacro:property name="max_effort_rotary" value="$(arg max_effort_rotary)" />
     <xacro:property name="max_effort_linear" value="$(arg max_effort_linear)" />


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
When looking at the short circuit errors I found that it only happens when efforts greater than 16000 are send. As far as I looked only the RKFE sends these high efforts and it is the only one with short circuit errors. Sometimes sending these efforts is okay, but a significant amount of time it results in a short circuit error. This is mainly because when you send an high effort the actual effort is often quite different (both higher and lower) sometimes resulting in doing efforts that are above the limits. The current limits are the theoretical limits, but as the effort command is not executed exactly, I think 16000 is a safe margin to make sure we do not have the short circuit error anymore. 

I don't know what the effects will be on the gaits, so may be we should airgait this first on a heavy gait. If this results in the joint not being able to follow the trajectory we might have to change the gait or come up with a real solution. 
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

<!-- Please don't forget to request for reviews -->
- lower max effort for rotational joints