### PR TITLE
New K-values for the kfe and hfe based on the improved inertias

### DIFF
--- a/march_description/urdf/march4.xacro
+++ b/march_description/urdf/march4.xacro
@@ -43,7 +43,7 @@
     <xacro:property name="k_position_value_kfe" value="$(arg k_position_value_kfe)" />
     <xacro:property name="k_position_value_haa" value="$(arg k_position_value_haa)" />
     <xacro:property name="k_position_value_adpf" value="$(arg k_position_value_adpf)" />
-z
+
     <!-- Constants for robot dimensions -->
     <!-- Masses determined in https://confluence.projectmarch.nl:8443/display/41TECH/Weights+of+the+Exoskeleton -->
     <xacro:property name="width" value="0.05"/> <!-- Square dimensions (widthxwidth) of beams -->

--- a/march_description/urdf/march4.xacro
+++ b/march_description/urdf/march4.xacro
@@ -35,15 +35,15 @@
     <xacro:property name="k_velocity_value_haa" value="$(arg k_velocity_value_haa)" />
     <xacro:property name="k_velocity_value_adpf" value="$(arg k_velocity_value_adpf)" />
 
-    <xacro:arg name="k_position_value_hfe" default="5.0" />
-    <xacro:arg name="k_position_value_kfe" default="5.0" />
+    <xacro:arg name="k_position_value_hfe" default="14.88" />
+    <xacro:arg name="k_position_value_kfe" default="14.88" />
     <xacro:arg name="k_position_value_haa" default="4.0" />
     <xacro:arg name="k_position_value_adpf" default="0.44" />
     <xacro:property name="k_position_value_hfe" value="$(arg k_position_value_hfe)" />
     <xacro:property name="k_position_value_kfe" value="$(arg k_position_value_kfe)" />
     <xacro:property name="k_position_value_haa" value="$(arg k_position_value_haa)" />
     <xacro:property name="k_position_value_adpf" value="$(arg k_position_value_adpf)" />
-
+z
     <!-- Constants for robot dimensions -->
     <!-- Masses determined in https://confluence.projectmarch.nl:8443/display/41TECH/Weights+of+the+Exoskeleton -->
     <xacro:property name="width" value="0.05"/> <!-- Square dimensions (widthxwidth) of beams -->


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Previously the same values as March IV were used as they were deemed safe. It however was never verified if these values are the maximum allowed velocities/efforts or not. Turns out they weren't and we have therefore been limiting way too much on the velocities.
The maple file that produces this result can be found on the NAS
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
new k-values of 14.88 instead of 5.0
<!-- Please don't forget to request for reviews -->
