### PR TITLE
Let gain scheduler fetch its inital pid values from parameter server

### DIFF
--- a/march_gain_scheduling/launch/march_gain_scheduling.launch
+++ b/march_gain_scheduling/launch/march_gain_scheduling.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="configuration" doc="Tuning configuration to use. Must be name of file in config/ directory."/>
     <arg name="linear" default="true" doc="Whether to linearize the change in PID values"/>
-    <arg name="slope" default="10.0" doc="The slope of the linear change in PID values. Only used when 'linear' is true"/>
+    <arg name="slope" default="200.0" doc="The slope of the linear change in PID values. Only used when 'linear' is true"/>
 
     <node name="gain_scheduling_node" pkg="march_gain_scheduling" type="march_gain_scheduling_node" output="screen">
         <rosparam command="load" file="$(find march_gain_scheduling)/config/$(arg configuration).yaml"/>

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -31,6 +31,7 @@ class DynamicPIDReconfigurer:
             self._gait_type = data.goal.current_subgait.gait_type
             self.interpolation_done = False
             rate = rospy.Rate(10)
+            self.last_update_time = rospy.get_time()
             while not self.interpolation_done:
                 rate.sleep()
                 self.client_update()

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -11,7 +11,10 @@ class DynamicPIDReconfigurer:
         self._gait_type = 'default'
         self._joint_list = joint_list
         self._max_time_step = max_time_step
-        self.current_gains = [self.look_up_table(i) for i in range(len(self._joint_list))]
+        self.current_gains = []
+        for joint_index in range(len(self._joint_list)):
+            gains = rospy.get_param('/march/controller/trajectory/gains/' + self._joint_list[joint_index])
+            self.current_gains.append([gains['p'], gains['i'], gains['d']])
         self.interpolation_done = True
         self.last_update_time = None
         self._clients = []
@@ -64,9 +67,6 @@ class DynamicPIDReconfigurer:
 
     # Method that pulls the PID values from the gains_per_gait_type.yaml config file
     def look_up_table(self, joint_index):
-        if (self._gait_type == 'default'):
-            gains = rospy.get_param('/march/controller/trajectory/gains/' + self._joint_list[joint_index])
-            return [gains['p'], gains['i'], gains['d']]
         if rospy.has_param('~gait_types/' + self._gait_type):
             gains = rospy.get_param('~gait_types/' + self._gait_type + '/' + self._joint_list[joint_index])
             return [gains['p'], gains['i'], gains['d']]

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -8,7 +8,7 @@ from .one_step_linear_interpolation import interpolate
 
 class DynamicPIDReconfigurer:
     def __init__(self, joint_list=None, max_time_step=0.1):
-        self._gait_type = 'default'
+        self._gait_type = None
         self._joint_list = joint_list
         self._max_time_step = max_time_step
         self.current_gains = []

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -13,7 +13,7 @@ class DynamicPIDReconfigurer:
         self._max_time_step = max_time_step
         self.current_gains = [self.look_up_table(i) for i in range(len(self._joint_list))]
         self.interpolation_done = True
-        self.last_update_time = 0
+        self.last_update_time = None
         self._clients = []
         for i in range(len(self._joint_list)):
             self._clients.append(Client('/march/controller/trajectory/gains/' + self._joint_list[i], timeout=30))

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -63,7 +63,7 @@ class DynamicPIDReconfigurer:
     # Method that pulls the PID values from the gains_per_gait_type.yaml config file
     def look_up_table(self, joint_index):
         if (self._gait_type == 'default'):
-            gains = rospy.get_param('~controller/trajectory/gains/' + self._joint_list[joint_index])
+            gains = rospy.get_param('/march/controller/trajectory/gains/' + self._joint_list[joint_index])
             return [gains['p'], gains['i'], gains['d']]
         if rospy.has_param('~gait_types/' + self._gait_type):
             gains = rospy.get_param('~gait_types/' + self._gait_type + '/' + self._joint_list[joint_index])

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -22,13 +22,14 @@ class DynamicPIDReconfigurer:
 
     def gait_selection_callback(self, data):
         rospy.logdebug('This is the gait name: %s', data.goal.current_subgait.gait_type)
-        if self._gait_type is None or self._gait_type == '':
-            self._gait_type = 'walk_like'
+        new_gait_type = data.goal.current_subgait.gait_type
+        if new_gait_type is None or new_gait_type == '':
+            new_gait_type = 'walk_like'
             rospy.logwarn('The gait has no gait type, default is set to walk_like')
-        if self._gait_type != data.goal.current_subgait.gait_type or not self.interpolation_done:
+        if self._gait_type != new_gait_type or not self.interpolation_done:
             rospy.logdebug('The selected gait: {0} is not the same as the previous gait: {1}'.format(
-                data.goal.current_subgait.gait_type, self._gait_type))
-            self._gait_type = data.goal.current_subgait.gait_type
+                new_gait_type, self._gait_type))
+            self._gait_type = new_gait_type
             self.interpolation_done = False
             rate = rospy.Rate(10)
             self.last_update_time = rospy.get_time()


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Read the initial values for current_gains from the parameter server so that it does not jump from zero to the walk_like tuning.

This is a temporary fix: it should be read from a topic at every callback so that you also can't wreck it by changing the pid values by hand.

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

<!-- Please don't forget to request for reviews -->
