### PR TITLE
Add /march/gait/current topic

### DIFF
--- a/march_state_machine/src/march_state_machine/state_machines/step_state_machine.py
+++ b/march_state_machine/src/march_state_machine/state_machines/step_state_machine.py
@@ -1,4 +1,6 @@
+import rospy
 import smach
+from std_msgs.msg import String
 
 from march_state_machine.control_flow import control_flow
 from march_state_machine.states.gait_state import GaitState
@@ -20,6 +22,7 @@ class StepStateMachine(smach.Sequence):
         """
         super(StepStateMachine, self).__init__(outcomes=['succeeded', 'preempted', 'failed'],
                                                connector_outcome='succeeded')
+        self._gait_name = gait_name
 
         if subgaits is None:
             subgaits = ['right_open', 'left_close']
@@ -30,6 +33,11 @@ class StepStateMachine(smach.Sequence):
         self.close()
 
         self.register_termination_cb(self._termination_cb)
+        self._gait_publisher = rospy.Publisher('/march/gait/current', String, queue_size=10)
+
+    def execute(self, ud=smach.UserData()):
+        self._gait_publisher.publish(self._gait_name)
+        return super(StepStateMachine, self).execute(ud)
 
     @staticmethod
     def _termination_cb(_userdata, _terminal_states, _outcome):

--- a/march_state_machine/src/march_state_machine/state_machines/step_state_machine.py
+++ b/march_state_machine/src/march_state_machine/state_machines/step_state_machine.py
@@ -1,12 +1,11 @@
-import rospy
 import smach
-from std_msgs.msg import String
 
-from march_state_machine.control_flow import control_flow
 from march_state_machine.states.gait_state import GaitState
 
+from .gait_state_machine import GaitStateMachine
 
-class StepStateMachine(smach.Sequence):
+
+class StepStateMachine(GaitStateMachine):
     """A smach.StateMachine that implements a gait with a sequence of subgaits."""
 
     def __init__(self, gait_name, subgaits=None):
@@ -20,25 +19,13 @@ class StepStateMachine(smach.Sequence):
         :param subgaits: List of subgaits to be performed in the given order.
                          When None, the subgaits will be ['right_open', 'left_close'].
         """
-        super(StepStateMachine, self).__init__(outcomes=['succeeded', 'preempted', 'failed'],
-                                               connector_outcome='succeeded')
-        self._gait_name = gait_name
+        super(StepStateMachine, self).__init__(gait_name)
 
         if subgaits is None:
             subgaits = ['right_open', 'left_close']
 
         self.open()
         for subgait in subgaits:
-            smach.Sequence.add(subgait, GaitState(gait_name, subgait), transitions={'aborted': 'failed'})
+            smach.Sequence.add_auto(subgait, GaitState(gait_name, subgait), connector_outcomes=['succeeded'],
+                                    transitions={'aborted': 'failed'})
         self.close()
-
-        self.register_termination_cb(self._termination_cb)
-        self._gait_publisher = rospy.Publisher('/march/gait/current', String, queue_size=10)
-
-    def execute(self, ud=smach.UserData()):
-        self._gait_publisher.publish(self._gait_name)
-        return super(StepStateMachine, self).execute(ud)
-
-    @staticmethod
-    def _termination_cb(_userdata, _terminal_states, _outcome):
-        control_flow.gait_finished()


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->


## Description
In order to make my life easier for PM-292, I created a topic `/march/gait/current` in the state machine which publishes the current gait as a string. This topic does not publish when gaits have finished.

## Changes
* Add `/march/gait/current` topic to `GaitStateMachine`
* Make `StepStateMachine` inherit from `GaitStateMachine` to reduce code duplication

<!-- Please don't forget to request for reviews -->
