### PR TITLE
Fix: interpolation steps

### DIFF
--- a/march_gain_scheduling/launch/march_gain_scheduling.launch
+++ b/march_gain_scheduling/launch/march_gain_scheduling.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="configuration" doc="Tuning configuration to use. Must be name of file in config/ directory."/>
     <arg name="linear" default="true" doc="Whether to linearize the change in PID values"/>
-    <arg name="slope" default="200.0" doc="The slope of the linear change in PID values. Only used when 'linear' is true"/>
+    <arg name="slope" default="100.0" doc="The slope of the linear change in PID values. Only used when 'linear' is true"/>
 
     <node name="gain_scheduling_node" pkg="march_gain_scheduling" type="march_gain_scheduling_node" output="screen">
         <rosparam command="load" file="$(find march_gain_scheduling)/config/$(arg configuration).yaml"/>

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -12,7 +12,8 @@ class DynamicPIDReconfigurer:
         self._joint_list = joint_list
         self.interpolation_done = True
         self._last_update_times = []
-        self._clients = [Client('/march/controller/trajectory/gains/' + j, timeout=30) for j in self._joint_list]
+        self._clients = [Client('/march/controller/trajectory/gains/' + joint, timeout=30) for joint in
+                         self._joint_list]
         self.current_gains = []
         rospy.Subscriber('/march/gait/schedule/goal', GaitActionGoal, callback=self.gait_selection_callback)
         self._linearize = rospy.get_param('~linearize_gain_scheduling')

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -7,63 +7,60 @@ from .one_step_linear_interpolation import interpolate
 
 
 class DynamicPIDReconfigurer:
-    def __init__(self, joint_list=None, max_time_step=0.1):
+    def __init__(self, joint_list):
         self._gait_type = None
         self._joint_list = joint_list
-        self._max_time_step = max_time_step
         self.interpolation_done = True
-        self.last_update_time = None
-        self._clients = []
+        self._last_update_times = []
+        self._clients = [Client('/march/controller/trajectory/gains/' + j, timeout=30) for j in self._joint_list]
         self.current_gains = []
-        for i in range(len(self._joint_list)):
-            self._clients.append(Client('/march/controller/trajectory/gains/' + self._joint_list[i], timeout=30))
         rospy.Subscriber('/march/gait/schedule/goal', GaitActionGoal, callback=self.gait_selection_callback)
         self._linearize = rospy.get_param('~linearize_gain_scheduling')
+        self._gradient = rospy.get_param('~linear_slope')
 
     def gait_selection_callback(self, data):
-        rospy.logdebug('This is the gait type: %s', data.goal.current_subgait.gait_type)
         new_gait_type = data.goal.current_subgait.gait_type
         if new_gait_type is None or new_gait_type == '':
             new_gait_type = 'walk_like'
             rospy.logwarn('The gait has no gait type, default is set to walk_like')
 
         if self._gait_type != new_gait_type or not self.interpolation_done:
-            rospy.logdebug('The selected gait: {0} is not the same as the previous gait: {1}'.format(
-                new_gait_type, self._gait_type))
-
-            self.load_current_gains()
             self._gait_type = new_gait_type
+            self.load_current_gains()
             self.interpolation_done = False
-            rate = rospy.Rate(10)
-            self.last_update_time = rospy.get_time()
-            while not self.interpolation_done:
-                rate.sleep()
-                self.client_update()
+            self._last_update_times = len(self._joint_list) * [rospy.get_time()]
 
-    def client_update(self):
-        rospy.logdebug('self.linearize is: {0}'.format(self._linearize))
+            needed_gains = [self.look_up_table(i) for i in range(len(self._joint_list))]
+            rate = rospy.Rate(10)
+
+            rospy.loginfo('Beginning PID interpolation for gait type: {}'.format(self._gait_type))
+            begin_interpolation_time = rospy.get_time()
+            while not self.interpolation_done:
+                self.client_update(needed_gains)
+                rate.sleep()
+            end_interpolation_time = rospy.get_time()
+            rospy.loginfo('PID interpolation finished in {}s'.format(end_interpolation_time - begin_interpolation_time))
+
+    def client_update(self, needed_gains):
         self.interpolation_done = True
 
         for i in range(len(self._joint_list)):
             if self._linearize:
-                needed_gains = self.look_up_table(i)
-                gradient = rospy.get_param('~linear_slope')
                 current_time = rospy.get_time()
-                time_interval = current_time - self.last_update_time
+                time_interval = current_time - self._last_update_times[i]
 
-                self.current_gains[i] = interpolate(self.current_gains[i], needed_gains, gradient, time_interval)
-                if self.current_gains[i] != needed_gains:
+                self.current_gains[i] = interpolate(self.current_gains[i], needed_gains[i], self._gradient,
+                                                    time_interval)
+                if self.current_gains[i] != needed_gains[i]:
                     self.interpolation_done = False
-                self.last_update_time = current_time
+
+                self._last_update_times[i] = rospy.get_time()
             else:
-                self.current_gains[i] = self.look_up_table(i)
+                self.current_gains[i] = needed_gains[i]
 
             self._clients[i].update_configuration({'p': self.current_gains[i][0],
                                                    'i': self.current_gains[i][1],
                                                    'd': self.current_gains[i][2]})
-            rospy.logdebug('Config set to {0}, {1}, {2}'.format(self.current_gains[i][0],
-                                                                self.current_gains[i][1],
-                                                                self.current_gains[i][2]))
 
     def load_current_gains(self):
         self.current_gains = []
@@ -73,8 +70,6 @@ class DynamicPIDReconfigurer:
 
     # Method that pulls the PID values from the gains_per_gait_type.yaml config file
     def look_up_table(self, joint_index):
-        if rospy.has_param('~gait_types/' + self._gait_type):
-            gains = rospy.get_param('~gait_types/' + self._gait_type + '/' + self._joint_list[joint_index])
-            return [gains['p'], gains['i'], gains['d']]
-        else:
-            return [None, None, None]
+        gains = rospy.get_param('~gait_types/' + self._gait_type + '/' + self._joint_list[joint_index],
+                                {'p': None, 'i': None, 'd': None})
+        return [gains['p'], gains['i'], gains['d']]

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -39,8 +39,7 @@ class DynamicPIDReconfigurer:
             while not self.interpolation_done:
                 self.client_update(needed_gains)
                 rate.sleep()
-            end_time = rospy.get_time()
-            rospy.loginfo('PID interpolation finished in {0}s'.format(end_time - begin_time))
+            rospy.loginfo('PID interpolation finished in {0}s'.format(rospy.get_time() - begin_time))
 
     def client_update(self, needed_gains):
         self.interpolation_done = True

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -28,13 +28,13 @@ class DynamicPIDReconfigurer:
             self._gait_type = new_gait_type
             self.load_current_gains()
             self.interpolation_done = False
-            self._last_update_times = len(self._joint_list) * [rospy.get_time()]
 
             needed_gains = [self.look_up_table(i) for i in range(len(self._joint_list))]
             rate = rospy.Rate(10)
 
             rospy.loginfo('Beginning PID interpolation for gait type: {0}'.format(self._gait_type))
             begin_time = rospy.get_time()
+            self._last_update_times = len(self._joint_list) * [begin_time]
             while not self.interpolation_done:
                 self.client_update(needed_gains)
                 rate.sleep()

--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -33,13 +33,13 @@ class DynamicPIDReconfigurer:
             needed_gains = [self.look_up_table(i) for i in range(len(self._joint_list))]
             rate = rospy.Rate(10)
 
-            rospy.loginfo('Beginning PID interpolation for gait type: {}'.format(self._gait_type))
-            begin_interpolation_time = rospy.get_time()
+            rospy.loginfo('Beginning PID interpolation for gait type: {0}'.format(self._gait_type))
+            begin_time = rospy.get_time()
             while not self.interpolation_done:
                 self.client_update(needed_gains)
                 rate.sleep()
-            end_interpolation_time = rospy.get_time()
-            rospy.loginfo('PID interpolation finished in {}s'.format(end_interpolation_time - begin_interpolation_time))
+            end_time = rospy.get_time()
+            rospy.loginfo('PID interpolation finished in {0}s'.format(end_time - begin_time))
 
     def client_update(self, needed_gains):
         self.interpolation_done = True

--- a/march_gain_scheduling/src/march_gain_scheduling/gain_scheduling_node.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/gain_scheduling_node.py
@@ -8,7 +8,7 @@ def main():
 
     while not rospy.is_shutdown() and not rospy.has_param('/march/joint_names'):
         rospy.sleep(0.5)
-        rospy.logdebug("Waiting on /march/joint_names to be available")
+        rospy.logdebug('Waiting on /march/joint_names to be available')
 
     if rospy.is_shutdown():
         return

--- a/march_gain_scheduling/src/march_gain_scheduling/gain_scheduling_node.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/gain_scheduling_node.py
@@ -4,9 +4,16 @@ from .dynamic_pid_reconfigurer import DynamicPIDReconfigurer
 
 
 def main():
-    # The parameters Joint_list and gait_list should be obtained from the parameter server of the workspace.
     rospy.init_node('march_gain_scheduling_node')
+
+    while not rospy.is_shutdown() and not rospy.has_param('/march/joint_names'):
+        rospy.sleep(0.5)
+        rospy.logdebug("Waiting on /march/joint_names to be available")
+
+    if rospy.is_shutdown():
+        return
+
     joint_list = rospy.get_param('/march/joint_names')
-    DynamicPIDReconfigurer(joint_list=joint_list)
+    DynamicPIDReconfigurer(joint_list)
 
     rospy.spin()


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-304

## Description
This PR fixes the issue where the interpolation would take a longer amount of time than was expected. It turns out that the `last_update_time` was used for every joint and updated on every joint, which resulted in the time_interval being very small. Besides this I also made some changes to improve the performance of the interpolation loop, by moving some parameter queries outside of the loop. The loop can now run at around 6Hz (The Dynamic Reconfigure client update is very slow) and the interpolation for `walk_like` and `sit_like` is now done in ~1.5 seconds.

## Changes
* Add a last update time for every joint
* Move parameter queries outside interpolate loop
* Change slope to 100

<!-- Please don't forget to request for reviews -->
