### PR TITLE
Fix use of CodeCoverage package

### DIFF
--- a/march_gait_scheduler/CMakeLists.txt
+++ b/march_gait_scheduler/CMakeLists.txt
@@ -30,6 +30,11 @@ catkin_package(
     trajectory_msgs
 )
 
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    append_coverage_compiler_flags()
+endif()
+
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
@@ -58,15 +63,9 @@ install(TARGETS ${PROJECT_NAME}_node
 
 ## Add gtest based cpp test target and link libraries
 if(CATKIN_ENABLE_TESTING)
-    find_package(code_coverage REQUIRED)
     find_package(rostest REQUIRED)
 
-    if(ENABLE_COVERAGE_TESTING)
-        include(CodeCoverage)
-        append_coverage_compiler_flags()
-    endif()
-
-    add_rostest_gmock(${PROJECT_NAME}-test
+    add_rostest_gtest(${PROJECT_NAME}_test
         test/launch/${PROJECT_NAME}.test
         test/rostest/test_runner.cpp
         test/rostest/schedule_one_gait_test.cpp
@@ -76,13 +75,13 @@ if(CATKIN_ENABLE_TESTING)
         test/rostest/callback_counter.cpp
     )
 
-    target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} ${PROJECT_NAME})
 
     if(ENABLE_COVERAGE_TESTING)
         set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
         add_code_coverage(
-            NAME ${PROJECT_NAME}_coverage
-            DEPENDS tests
+            NAME coverage_report
+            DEPENDENCIES ${PROJECT_NAME}_test
         )
     endif()
 endif()

--- a/march_gait_scheduler/test/launch/march_gait_scheduler.test
+++ b/march_gait_scheduler/test/launch/march_gait_scheduler.test
@@ -1,4 +1,4 @@
 <launch>
     <node name="gait_scheduler_node" pkg="march_gait_scheduler" type="march_gait_scheduler_node" output="screen"/>
-    <test test-name="march_gait_scheduler_tests" pkg="march_gait_scheduler" type="march_gait_scheduler-test"/>
+    <test test-name="march_gait_scheduler_tests" pkg="march_gait_scheduler" type="march_gait_scheduler_test"/>
 </launch>

--- a/march_safety/CMakeLists.txt
+++ b/march_safety/CMakeLists.txt
@@ -29,6 +29,11 @@ include_directories(
     ${catkin_INCLUDE_DIRS}
 )
 
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    append_coverage_compiler_flags()
+endif()
+
 add_library(${PROJECT_NAME}
     src/input_device_safety.cpp
     src/safety_handler.cpp
@@ -55,13 +60,7 @@ install(DIRECTORY launch sound
 
 # Add gtest based cpp test target and link libraries
 if(CATKIN_ENABLE_TESTING)
-    find_package(code_coverage REQUIRED)
     find_package(rostest REQUIRED)
-
-    if(ENABLE_COVERAGE_TESTING)
-        include(CodeCoverage)
-        append_coverage_compiler_flags()
-    endif()
 
     add_rostest_gtest(${PROJECT_NAME}_temperature_test
         test/launch/${PROJECT_NAME}_temperature.test
@@ -91,8 +90,12 @@ if(CATKIN_ENABLE_TESTING)
     if(ENABLE_COVERAGE_TESTING)
         set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
         add_code_coverage(
-            NAME ${PROJECT_NAME}_coverage
-            DEPENDS tests
+            NAME coverage_report
+            DEPENDENCIES
+            ${PROJECT_NAME}_temperature_test
+            ${PROJECT_NAME}_connection_lost_test
+            ${PROJECT_NAME}_connection_never_started_test
+            ${PROJECT_NAME}_connection_not_lost_test
         )
     endif()
 endif()


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Partly closes PM-79

## Description
A long time ago I created the `feature/PM-79-add-coverage-report` branch, which would add coverage reports. In there I discovered that the `CodeCoverage` package was not being used correctly according to https://github.com/mikeferguson/code_coverage. This fixes the issue where you get a warning when trying to build in `Release` that code coverage is not reliable. Now the coverage reports will only be generated when `ENABLE_COVERAGE_TESTING` is enabled.


<!-- Please don't forget to request for reviews -->
