### PR TITLE
Fix: remove GLOB

### DIFF
--- a/march_description/CMakeLists.txt
+++ b/march_description/CMakeLists.txt
@@ -7,8 +7,13 @@ catkin_package(CFG_EXTRAS ${PROJECT_NAME}-extras.cmake)
 
 include(cmake/${PROJECT_NAME}-extras.cmake)
 
-file(GLOB xacro_files urdf/*.xacro)
-build_and_install_xacro_files(${xacro_files})
+set(XACRO_FILES
+    urdf/march3.xacro
+    urdf/march4.xacro
+    urdf/test_joint_linear.xacro
+    urdf/test_joint_rotational.xacro
+)
+build_and_install_xacro_files(${XACRO_FILES})
 
 install(DIRECTORY urdf
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
While I was updating the documentation for `march_description` (see project-march/tutorials#121), I discovered that using `GLOB`s in CMake is discouraged: 

* [Is it better to specify source files with GLOB or each file individually?](https://stackoverflow.com/questions/1027247/is-it-better-to-specify-source-files-with-glob-or-each-file-individually-in-cmake)
* [Why is cmake GLOB evil?](https://stackoverflow.com/questions/32411963/why-is-cmake-file-glob-evil)

It makes CMake unable to detect any newly added or removed files.

## Changes
* Remove glob and change to list of xacro files

<!-- Please don't forget to request for reviews -->
