### PR TITLE
Fix: unallowed gaits

### DIFF
--- a/march_gait_selection/src/march_gait_selection/gait_selection_node.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection_node.py
@@ -4,7 +4,7 @@ import rospy
 from std_srvs.srv import Trigger
 
 from march_shared_classes.exceptions.gait_exceptions import GaitError
-from march_shared_resources.srv import ContainsGait, ContainsGaitResponse, ContainsGaitRequest, StringTrigger
+from march_shared_resources.srv import ContainsGait, ContainsGaitResponse, StringTrigger
 
 from .gait_selection import GaitSelection
 from .perform_gait_action import PerformGaitAction

--- a/march_gait_selection/src/march_gait_selection/gait_selection_node.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection_node.py
@@ -4,11 +4,10 @@ import rospy
 from std_srvs.srv import Trigger
 
 from march_shared_classes.exceptions.gait_exceptions import GaitError
-from march_shared_resources.srv import StringTrigger
+from march_shared_resources.srv import ContainsGait, ContainsGaitResponse, ContainsGaitRequest, StringTrigger
 
 from .gait_selection import GaitSelection
 from .perform_gait_action import PerformGaitAction
-
 
 NODE_NAME = 'gait_selection'
 GAIT_FILES_MAP_NAME = 'march_gait_files'
@@ -32,6 +31,26 @@ def set_gait_version_map(msg, gait_selection):
         return [False, 'Error occurred when constructing gaits: {er}'.format(er=e)]
 
 
+def contains_gait(request, gait_selection):
+    """
+    Checks whether a gait and subgait are loaded.
+
+    :type request: ContainsGaitRequest
+    :param request: service request
+    :param gait_selection: current loaded gaits
+    :return: True when the gait and subgait are loaded
+    """
+    gait = gait_selection[request.gait]
+    if gait is not None:
+        for subgait in request.subgaits:
+            if gait[subgait] is None:
+                return ContainsGaitResponse(False)
+    else:
+        return ContainsGaitResponse(False)
+
+    return ContainsGaitResponse(True)
+
+
 def main():
     rospy.init_node(NODE_NAME)
     gait_package = rospy.get_param('~gait_package', GAIT_FILES_MAP_NAME)
@@ -51,6 +70,9 @@ def main():
 
     rospy.Service('/march/gait_selection/update_default_versions', Trigger,
                   lambda msg: gait_selection.update_default_versions())
+
+    rospy.Service('/march/gait_selection/contains_gait', ContainsGait,
+                  lambda msg: contains_gait(msg, gait_selection))
 
     PerformGaitAction(gait_selection)
     rospy.spin()

--- a/march_gait_selection/src/march_gait_selection/gait_selection_node.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection_node.py
@@ -41,12 +41,11 @@ def contains_gait(request, gait_selection):
     :return: True when the gait and subgait are loaded
     """
     gait = gait_selection[request.gait]
-    if gait is not None:
-        for subgait in request.subgaits:
-            if gait[subgait] is None:
-                return ContainsGaitResponse(False)
-    else:
+    if gait is None:
         return ContainsGaitResponse(False)
+    for subgait in request.subgaits:
+        if gait[subgait] is None:
+            return ContainsGaitResponse(False)
 
     return ContainsGaitResponse(True)
 

--- a/march_launch/launch/march.launch
+++ b/march_launch/launch/march.launch
@@ -67,11 +67,11 @@
             <arg name="ping_safety_node" value="true"/>
         </include>
 
-<!--        <include file="$(find march_data_collector)/launch/march_data_collector.launch">-->
-<!--            <arg name="esp" value="$(arg esp)"/>-->
-<!--            <arg name="pressure_soles" value="$(arg pressure_soles)"/>-->
-<!--            <arg name="moticon_ip" value="$(arg moticon_ip)"/>-->
-<!--        </include>-->
+        <include file="$(find march_data_collector)/launch/march_data_collector.launch">
+            <arg name="esp" value="$(arg esp)"/>
+            <arg name="pressure_soles" value="$(arg pressure_soles)"/>
+            <arg name="moticon_ip" value="$(arg moticon_ip)"/>
+        </include>
     </group>
 
     <group if="$(eval configuration == 'exoskeleton')">

--- a/march_launch/launch/march.launch
+++ b/march_launch/launch/march.launch
@@ -67,11 +67,11 @@
             <arg name="ping_safety_node" value="true"/>
         </include>
 
-        <include file="$(find march_data_collector)/launch/march_data_collector.launch">
-            <arg name="esp" value="$(arg esp)"/>
-            <arg name="pressure_soles" value="$(arg pressure_soles)"/>
-            <arg name="moticon_ip" value="$(arg moticon_ip)"/>
-        </include>
+<!--        <include file="$(find march_data_collector)/launch/march_data_collector.launch">-->
+<!--            <arg name="esp" value="$(arg esp)"/>-->
+<!--            <arg name="pressure_soles" value="$(arg pressure_soles)"/>-->
+<!--            <arg name="moticon_ip" value="$(arg moticon_ip)"/>-->
+<!--        </include>-->
     </group>
 
     <group if="$(eval configuration == 'exoskeleton')">

--- a/march_shared_resources/CMakeLists.txt
+++ b/march_shared_resources/CMakeLists.txt
@@ -29,6 +29,7 @@ add_message_files(
 
 add_service_files(
     FILES
+    ContainsGait.srv
     CurrentState.srv
     PossibleGaits.srv
     StringTrigger.srv

--- a/march_shared_resources/srv/ContainsGait.srv
+++ b/march_shared_resources/srv/ContainsGait.srv
@@ -1,0 +1,4 @@
+string gait
+string[] subgaits
+---
+bool contains

--- a/march_state_machine/src/march_state_machine/gaits/slope_down_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/slope_down_sm.py
@@ -6,15 +6,16 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_slope_down = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    sm_slope_down = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
     sm_slope_down.register_io_keys(['sounds'])
     with sm_slope_down:
         smach.StateMachine.add('GAIT RD SLOPE DOWN', SlopeStateMachine('ramp_door_slope_down'),
-                               transitions={'succeeded': 'STANDING SLOPE DOWN', 'failed': 'failed'})
+                               transitions={'succeeded': 'STANDING SLOPE DOWN'})
 
         smach.StateMachine.add('STANDING SLOPE DOWN', IdleState(outcomes=['gait_ramp_door_last_step', 'preempted']),
                                transitions={'gait_ramp_door_last_step': 'GAIT RD LAST STEP'})
 
-        smach.StateMachine.add('GAIT RD LAST STEP', StepStateMachine('ramp_door_last_step'))
+        smach.StateMachine.add('GAIT RD LAST STEP', StepStateMachine('ramp_door_last_step'),
+                               transitions={'rejected': 'STANDING SLOPE DOWN'})
 
     return sm_slope_down

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_left_flexed_knee_step_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_left_flexed_knee_step_sm.py
@@ -5,16 +5,17 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_tilted_path_left_flexed_knee_step = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
-    sm_tilted_path_left_flexed_knee_step .register_io_keys(['sounds'])
+    sm_tilted_path_left_flexed_knee_step = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
+    sm_tilted_path_left_flexed_knee_step.register_io_keys(['sounds'])
     with sm_tilted_path_left_flexed_knee_step:
         smach.StateMachine.add('GAIT TP LEFT FLEXED KNEE STEP', StepStateMachine('tilted_path_left_flexed_knee_step',
-                               subgaits=['right_open', 'left_close']),
-                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT', 'failed': 'failed'})
+                                                                                 subgaits=['right_open', 'left_close']),
+                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT'})
 
         smach.StateMachine.add('GAIT TP LEFT SINGLE STEP', StepStateMachine('tilted_path_left_single_step',
-                               subgaits=['right_open', 'left_close']),
-                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT', 'failed': 'failed'})
+                                                                            subgaits=['right_open', 'left_close']),
+                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT',
+                                            'rejected': 'STANDING TP LEFT STRAIGHT'})
 
         smach.StateMachine.add('STANDING TP LEFT STRAIGHT', IdleState(outcomes=['gait_tilted_path_left_single_step',
                                                                                 'gait_tilted_path_left_straight_end',
@@ -23,6 +24,7 @@ def create():
                                             'gait_tilted_path_left_straight_end': 'GAIT TP LEFT STRAIGHT END'})
 
         smach.StateMachine.add('GAIT TP LEFT STRAIGHT END', StepStateMachine('tilted_path_left_straight_end',
-                                                                             subgaits=['left_open', 'right_close']))
+                                                                             subgaits=['left_open', 'right_close']),
+                               transitions={'rejected': 'STANDING TP LEFT STRAIGHT'})
 
     return sm_tilted_path_left_flexed_knee_step

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_left_straight_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_left_straight_sm.py
@@ -5,16 +5,17 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_tilted_path_left_straight = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    sm_tilted_path_left_straight = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
     sm_tilted_path_left_straight.register_io_keys(['sounds'])
     with sm_tilted_path_left_straight:
         smach.StateMachine.add('GAIT TP LEFT STRAIGHT START', StepStateMachine('tilted_path_left_straight_start',
-                               subgaits=['right_open', 'left_close']),
-                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT', 'failed': 'failed'})
+                                                                               subgaits=['right_open', 'left_close']),
+                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT'})
 
         smach.StateMachine.add('GAIT TP LEFT SINGLE STEP', StepStateMachine('tilted_path_left_single_step',
-                               subgaits=['right_open', 'left_close']),
-                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT', 'failed': 'failed'})
+                                                                            subgaits=['right_open', 'left_close']),
+                               transitions={'succeeded': 'STANDING TP LEFT STRAIGHT',
+                                            'rejected': 'STANDING TP LEFT STRAIGHT'})
 
         smach.StateMachine.add('STANDING TP LEFT STRAIGHT', IdleState(outcomes=['gait_tilted_path_left_single_step',
                                                                                 'gait_tilted_path_left_straight_end',
@@ -23,6 +24,7 @@ def create():
                                             'gait_tilted_path_left_straight_end': 'GAIT TP LEFT STRAIGHT END'})
 
         smach.StateMachine.add('GAIT TP LEFT STRAIGHT END', StepStateMachine('tilted_path_left_straight_end',
-                                                                             subgaits=['left_open', 'right_close']))
+                                                                             subgaits=['left_open', 'right_close']),
+                               transitions={'rejected': 'STANDING TP LEFT STRAIGHT'})
 
     return sm_tilted_path_left_straight

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_right_flexed_knee_step_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_right_flexed_knee_step_sm.py
@@ -5,16 +5,19 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_tilted_path_right_flexed_knee_step = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    sm_tilted_path_right_flexed_knee_step = smach.StateMachine(
+        outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
     sm_tilted_path_right_flexed_knee_step.register_io_keys(['sounds'])
     with sm_tilted_path_right_flexed_knee_step:
         smach.StateMachine.add('GAIT TP RIGHT FLEXED KNEE STEP', StepStateMachine('tilted_path_right_flexed_knee_step',
-                               subgaits=['left_open', 'right_close']),
-                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT', 'failed': 'failed'})
+                                                                                  subgaits=['left_open',
+                                                                                            'right_close']),
+                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT'})
 
         smach.StateMachine.add('GAIT TP RIGHT SINGLE STEP', StepStateMachine('tilted_path_right_single_step',
-                               subgaits=['left_open', 'right_close']),
-                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT', 'failed': 'failed'})
+                                                                             subgaits=['left_open', 'right_close']),
+                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT',
+                                            'rejected': 'STANDING TP RIGHT STRAIGHT'})
 
         smach.StateMachine.add('STANDING TP RIGHT STRAIGHT', IdleState(outcomes=['gait_tilted_path_right_single_step',
                                                                                  'gait_tilted_path_right_straight_end',
@@ -23,6 +26,7 @@ def create():
                                             'gait_tilted_path_right_straight_end': 'GAIT TP RIGHT STRAIGHT END'})
 
         smach.StateMachine.add('GAIT TP RIGHT STRAIGHT END', StepStateMachine('tilted_path_right_straight_end',
-                                                                              subgaits=['right_open', 'left_close']))
+                                                                              subgaits=['right_open', 'left_close']),
+                               transitions={'rejected': 'STANDING TP RIGHT STRAIGHT'})
 
     return sm_tilted_path_right_flexed_knee_step

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_right_straight_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_right_straight_sm.py
@@ -5,16 +5,17 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_tilted_path_right_straight = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    sm_tilted_path_right_straight = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
     sm_tilted_path_right_straight.register_io_keys(['sounds'])
     with sm_tilted_path_right_straight:
         smach.StateMachine.add('GAIT TP RIGHT STRAIGHT START', StepStateMachine('tilted_path_right_straight_start',
-                               subgaits=['left_open', 'right_close']),
-                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT', 'failed': 'failed'})
+                                                                                subgaits=['left_open', 'right_close']),
+                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT'})
 
         smach.StateMachine.add('GAIT TP RIGHT SINGLE STEP', StepStateMachine('tilted_path_right_single_step',
-                               subgaits=['left_open', 'right_close']),
-                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT', 'failed': 'failed'})
+                                                                             subgaits=['left_open', 'right_close']),
+                               transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT',
+                                            'rejected': 'STANDING TP RIGHT STRAIGHT'})
 
         smach.StateMachine.add('STANDING TP RIGHT STRAIGHT', IdleState(outcomes=['gait_tilted_path_right_single_step',
                                                                                  'gait_tilted_path_right_straight_end',
@@ -23,6 +24,7 @@ def create():
                                             'gait_tilted_path_right_straight_end': 'GAIT TP RIGHT STRAIGHT END'})
 
         smach.StateMachine.add('GAIT TP RIGHT STRAIGHT END', StepStateMachine('tilted_path_right_straight_end',
-                                                                              subgaits=['right_open', 'left_close']))
+                                                                              subgaits=['right_open', 'left_close']),
+                               transitions={'rejected': 'STANDING TP RIGHT STRAIGHT'})
 
     return sm_tilted_path_right_straight

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
@@ -5,18 +5,19 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_tilted_path_sideways_end = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    sm_tilted_path_sideways_end = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
     sm_tilted_path_sideways_end.register_io_keys(['sounds'])
     with sm_tilted_path_sideways_end:
         smach.StateMachine.add('GAIT TP FIRST END', StepStateMachine('tilted_path_first_end',
                                                                      subgaits=['left_open', 'right_close']),
-                               transitions={'succeeded': 'STANDING TP SIDEWAYS END', 'failed': 'failed'})
+                               transitions={'succeeded': 'STANDING TP SIDEWAYS END'})
 
         smach.StateMachine.add('STANDING TP SIDEWAYS END', IdleState(outcomes=['gait_tilted_path_second_end',
-                                                                     'preempted']),
+                                                                               'preempted']),
                                transitions={'gait_tilted_path_second_end': 'GAIT TP SECOND END'})
 
         smach.StateMachine.add('GAIT TP SECOND END', StepStateMachine('tilted_path_second_end',
-                                                                      subgaits=['left_open', 'right_close']))
+                                                                      subgaits=['left_open', 'right_close']),
+                               transitions={'rejected': 'STANDING TP SIDEWAYS END'})
 
     return sm_tilted_path_sideways_end

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
@@ -5,18 +5,19 @@ from march_state_machine.states.idle_state import IdleState
 
 
 def create():
-    sm_tilted_path_sideways_start = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed'])
+    sm_tilted_path_sideways_start = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
     sm_tilted_path_sideways_start.register_io_keys(['sounds'])
     with sm_tilted_path_sideways_start:
         smach.StateMachine.add('GAIT TP FIRST START', StepStateMachine('tilted_path_first_start',
                                                                        subgaits=['left_open', 'right_close']),
-                               transitions={'succeeded': 'STANDING TP SIDEWAYS START', 'failed': 'failed'})
+                               transitions={'succeeded': 'STANDING TP SIDEWAYS START'})
 
         smach.StateMachine.add('STANDING TP SIDEWAYS START', IdleState(outcomes=['gait_tilted_path_second_start',
-                                                                       'preempted']),
+                                                                                 'preempted']),
                                transitions={'gait_tilted_path_second_start': 'GAIT TP SECOND START'})
 
         smach.StateMachine.add('GAIT TP SECOND START', StepStateMachine('tilted_path_second_start',
-                                                                        subgaits=['left_open', 'right_close']))
+                                                                        subgaits=['left_open', 'right_close']),
+                               transitions={'rejected': 'STANDING TP SIDEWAYS START'})
 
     return sm_tilted_path_sideways_start

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -52,8 +52,8 @@ class HealthyStateMachine(smach.StateMachine):
         self.add('UNKNOWN', IdleState(outcomes=['home_sit', 'home_stand', 'failed', 'preempted']),
                  transitions={'home_sit': 'HOME SIT', 'home_stand': 'HOME STAND'})
 
-        self.add_state('HOME SIT', StepStateMachine('home', ['home_sit']), 'SITTING')
-        self.add_state('HOME STAND', StepStateMachine('home', ['home_stand']), 'STANDING')
+        self.add_state('HOME SIT', StepStateMachine('home', ['home_sit']), 'SITTING', rejected='UNKNOWN')
+        self.add_state('HOME STAND', StepStateMachine('home', ['home_stand']), 'STANDING', rejected='UNKNOWN')
 
         walking_state_machine = StateMachineWithTransition(['walk_small', 'walk', 'walk_large'])
         walking_state_machine.add('walk', WalkStateMachine('walk', is_transition_active=True))
@@ -64,8 +64,9 @@ class HealthyStateMachine(smach.StateMachine):
         self.add_state('GAIT WALK SMALL', walking_state_machine, 'STANDING', custom_start_label='walk_small')
         self.add_state('GAIT WALK LARGE', walking_state_machine, 'STANDING', custom_start_label='walk_large')
 
-        self.add_state('GAIT SIT', StepStateMachine('sit', ['sit_down', 'sit_home']), 'SITTING')
-        self.add_state('GAIT STAND', StepStateMachine('stand', ['prepare_stand_up', 'stand_up']), 'STANDING')
+        self.add_state('GAIT SIT', StepStateMachine('sit', ['sit_down', 'sit_home']), 'SITTING', rejected='STANDING')
+        self.add_state('GAIT STAND', StepStateMachine('stand', ['prepare_stand_up', 'stand_up']), 'STANDING',
+                       rejected='SITTING')
 
         self.add_state('GAIT SINGLE STEP SMALL', StepStateMachine('single_step_small'), 'STANDING')
         self.add_state('GAIT SINGLE STEP NORMAL', StepStateMachine('single_step_normal'), 'STANDING')
@@ -80,10 +81,12 @@ class HealthyStateMachine(smach.StateMachine):
         self.add_state('GAIT SIDE STEP RIGHT', StepStateMachine('side_step_right'), 'STANDING')
         self.add_state('GAIT SIDE STEP RIGHT SMALL', StepStateMachine('side_step_right_small'), 'STANDING')
 
-        self.add_state('GAIT SOFA SIT', StepStateMachine('sofa_sit', ['sit_down', 'sit_home']), 'SOFA SITTING')
+        self.add_state('GAIT SOFA SIT', StepStateMachine('sofa_sit', ['sit_down', 'sit_home']), 'SOFA SITTING',
+                       rejected='STANDING')
         self.add('SOFA SITTING', IdleState(outcomes=['gait_sofa_stand', 'preempted']),
                  transitions={'gait_sofa_stand': 'GAIT SOFA STAND'})
-        self.add_state('GAIT SOFA STAND', StepStateMachine('sofa_stand', ['prepare_stand_up', 'stand_up']), 'STANDING')
+        self.add_state('GAIT SOFA STAND', StepStateMachine('sofa_stand', ['prepare_stand_up', 'stand_up']), 'STANDING',
+                       rejected='SOFA SITTING')
 
         self.add_state('GAIT STAIRS UP', WalkStateMachine('stairs_up'), 'STANDING')
         self.add_state('GAIT STAIRS DOWN', WalkStateMachine('stairs_down'), 'STANDING')
@@ -167,7 +170,7 @@ class HealthyStateMachine(smach.StateMachine):
                               'gait_tilted_path_first_end': 'GAIT TP SIDEWAYS END'})
         self.close()
 
-    def add_state(self, label, state, succeeded, custom_start_label=None):
+    def add_state(self, label, state, succeeded, rejected=None, custom_start_label=None):
         """Adds a state to the healthy state machine.
 
         The healthy state machine should be opened before using this method.
@@ -175,14 +178,18 @@ class HealthyStateMachine(smach.StateMachine):
         :type label: str
         :param label: name of the state
         :type state: smach.State
-        :param state: State (or statemachine to be added)
+        :param state: State (or statemachine) to be added
         :type succeeded: str
         :param succeeded: name of the state that the given state should transition to once succeeded
+        :type rejected: str
+        :param rejected: name of the state that the given state should transition to once rejected
         :type custom_start_label: str
         :param custom_start_label: name of the start state within the given state machine
         """
         self.assert_opened()
-        self.add(label, state, transitions={'succeeded': succeeded, 'failed': 'UNKNOWN'})
+        if rejected is None:
+            rejected = succeeded
+        self.add(label, state, transitions={'succeeded': succeeded, 'failed': 'UNKNOWN', 'rejected': rejected})
 
         if custom_start_label is not None:
             self._custom_start_states[label] = custom_start_label
@@ -193,7 +200,7 @@ class HealthyStateMachine(smach.StateMachine):
         :type _req: march_shared_resources.srv.PossibleGaitsRequest
         :rtype march_shared_resources.srv.PossibleGaitsResponse
         """
-        non_gaits = ['succeeded', 'failed', 'preempted', 'aborted']
+        non_gaits = ['succeeded', 'failed', 'preempted', 'aborted', 'rejected']
         gaits = []
         if self.is_running():
             gaits = [k for k in self._current_transitions.keys() if k not in non_gaits]

--- a/march_state_machine/src/march_state_machine/state_machines/gait_state_machine.py
+++ b/march_state_machine/src/march_state_machine/state_machines/gait_state_machine.py
@@ -3,7 +3,6 @@ import smach
 from std_msgs.msg import String
 
 from march_shared_resources.srv import ContainsGait
-
 from march_state_machine.control_flow import control_flow
 from march_state_machine.states.gait_state import GaitState
 from march_state_machine.states.stoppable_state import StoppableState

--- a/march_state_machine/src/march_state_machine/state_machines/gait_state_machine.py
+++ b/march_state_machine/src/march_state_machine/state_machines/gait_state_machine.py
@@ -2,6 +2,8 @@ import rospy
 import smach
 from std_msgs.msg import String
 
+from march_shared_resources.srv import ContainsGait
+
 from march_state_machine.control_flow import control_flow
 from march_state_machine.states.gait_state import GaitState
 from march_state_machine.states.stoppable_state import StoppableState
@@ -10,11 +12,16 @@ from march_state_machine.states.stoppable_state import StoppableState
 class GaitStateMachine(smach.StateMachine):
     """A march gait implemented as a smach.StateMachine."""
 
+    CURRENT_GAIT_PUB = rospy.Publisher('/march/gait/current', String, queue_size=10)
+    CONTAINS_GAIT = rospy.ServiceProxy('/march/gait_selection/contains_gait', ContainsGait)
+
     def __init__(self, gait_name):
-        super(GaitStateMachine, self).__init__(outcomes=['succeeded', 'preempted', 'failed'], input_keys=['sounds'],
+        super(GaitStateMachine, self).__init__(outcomes=['succeeded', 'preempted', 'failed', 'rejected'],
+                                               input_keys=['sounds'],
                                                output_keys=['sounds'])
         self._gait_name = gait_name
-        self._gait_publisher = rospy.Publisher('/march/gait/current', String, queue_size=10)
+        self._gait_publisher = GaitStateMachine.CURRENT_GAIT_PUB
+        self._contains_gait = GaitStateMachine.CONTAINS_GAIT
 
         self.register_start_cb(self._start_cb)
         self.register_termination_cb(self._termination_cb)
@@ -53,6 +60,16 @@ class GaitStateMachine(smach.StateMachine):
                                    transitions={'succeeded': succeeded, 'aborted': 'failed'})
 
     def execute(self, ud=smach.UserData()):
+        try:
+            subgaits = self.get_children().keys()
+            if not self._contains_gait(gait=self._gait_name, subgaits=subgaits).contains:
+                rospy.logwarn('Gait {0} is not currently loaded with subgaits {1}'.format(self._gait_name, subgaits))
+                return 'rejected'
+        except rospy.ServiceException:
+            rospy.logerr(
+                'Failed to contact {0}, is a gait_selection node running?'.format(self._contains_gait.resolved_name))
+            return 'failed'
+
         self._gait_publisher.publish(self._gait_name)
         return super(GaitStateMachine, self).execute(ud)
 

--- a/march_state_machine/src/march_state_machine/state_machines/transition_state_machine.py
+++ b/march_state_machine/src/march_state_machine/state_machines/transition_state_machine.py
@@ -9,7 +9,7 @@ from march_state_machine.states.transition_state import TransitionState
 
 class StateMachineWithTransition(smach.StateMachine):
     def __init__(self, transition_sequence, outcomes=None):
-        self._default_outcomes = ['succeeded', 'preempted', 'failed']
+        self._default_outcomes = ['succeeded', 'preempted', 'failed', 'rejected']
         self._transition_sequence = transition_sequence
 
         if outcomes is not None:

--- a/march_state_machine/src/march_state_machine/state_machines/transition_state_machine.py
+++ b/march_state_machine/src/march_state_machine/state_machines/transition_state_machine.py
@@ -68,7 +68,7 @@ class StateMachineWithTransition(smach.StateMachine):
             pass
 
         if self.initial_state_label not in self._transition_sequence:
-            return 'succeeded'
+            return 'rejected'
 
         return super(StateMachineWithTransition, self).execute(parent_ud)
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-307

## Description
This fixes the issue where gaits executed in the state machine that are not loaded in gait selection will transition the state machine to `UNKNOWN`. With this fix the gait state machine will return a `rejected` outcome and the state machine will recover from it and go back to the original state. I have implemented this as a service on the gait selection that enables the state machine to ask whether a gait with subgaits is currently loaded. At first I thought it would be possible to make the action server in gait selection reject the action request, however this was not possible with the `SimpleActionServer` and required implementing your own `ActionServer` from actionlib. See https://github.com/ros/actionlib/issues/38 for more info.

## Changes
* Implement `/march/gait_selection/contains_gait` service
* Add `ContainsGait.srv` description
* Add `rejected` outcome to gait state machines and transition state machine

<!-- Please don't forget to request for reviews -->
