### PR TITLE
Fix/Changed wrong Motor Voltage naming

### DIFF
--- a/march_data_collector/src/march_data_collector/esp_adapter.py
+++ b/march_data_collector/src/march_data_collector/esp_adapter.py
@@ -257,12 +257,12 @@ class ESPAdapter:
         :param source: the name of the source window in the ESP engine
         """
         motor_current_str = ','.join([str(value) for value in data.motor_current])
-        IMC_voltage_str = ','.join([str(value) for value in data.IMC_voltage])
+        imc_voltage_str = ','.join([str(value) for value in data.imc_voltage])
         absolute_encoder_str = ','.join([str(value) for value in data.absolute_encoder_value])
         incremental_encoder_str = ','.join([str(value) for value in data.incremental_encoder_value])
         time_str = get_time_str(data.header.stamp)
 
-        csv = ','.join([time_str, IMC_voltage_str, motor_current_str, absolute_encoder_str, incremental_encoder_str])
+        csv = ','.join([time_str, imc_voltage_str, motor_current_str, absolute_encoder_str, incremental_encoder_str])
         self.send_to_esp(csv, source)
 
     def gait_callback(self, data, source):

--- a/march_data_collector/src/march_data_collector/esp_adapter.py
+++ b/march_data_collector/src/march_data_collector/esp_adapter.py
@@ -257,12 +257,12 @@ class ESPAdapter:
         :param source: the name of the source window in the ESP engine
         """
         motor_current_str = ','.join([str(value) for value in data.motor_current])
-        motor_voltage_str = ','.join([str(value) for value in data.motor_voltage])
+        IMC_voltage_str = ','.join([str(value) for value in data.IMC_voltage])
         absolute_encoder_str = ','.join([str(value) for value in data.absolute_encoder_value])
         incremental_encoder_str = ','.join([str(value) for value in data.incremental_encoder_value])
         time_str = get_time_str(data.header.stamp)
 
-        csv = ','.join([time_str, motor_voltage_str, motor_current_str, absolute_encoder_str, incremental_encoder_str])
+        csv = ','.join([time_str, IMC_voltage_str, motor_current_str, absolute_encoder_str, incremental_encoder_str])
         self.send_to_esp(csv, source)
 
     def gait_callback(self, data, source):

--- a/march_shared_resources/msg/ImcState.msg
+++ b/march_shared_resources/msg/ImcState.msg
@@ -7,6 +7,6 @@ string[] state
 string[] detailed_error_description
 string[] motion_error_description
 float32[] motor_current
-float32[] motor_voltage
+float32[] IMC_voltage
 int32[] absolute_encoder_value
 int32[] incremental_encoder_value

--- a/march_shared_resources/msg/ImcState.msg
+++ b/march_shared_resources/msg/ImcState.msg
@@ -7,6 +7,6 @@ string[] state
 string[] detailed_error_description
 string[] motion_error_description
 float32[] motor_current
-float32[] IMC_voltage
+float32[] imc_voltage
 int32[] absolute_encoder_value
 int32[] incremental_encoder_value


### PR DESCRIPTION
Fix/Changed wrong Motor Voltage naming

Dependent on "Fix/Changed wrong motor voltage reading project-march/hardware-interface#247" (HWI)

Part of
PM-300-add-motorvoltage

## Description
Fixes the naming of the wrong motor voltage to IMC voltage

## Changes

* Renamed variable
