### PR TITLE
Feature/pm 393 correct height imu tf

### DIFF
--- a/march_data_collector/src/march_data_collector/data_collector_node.py
+++ b/march_data_collector/src/march_data_collector/data_collector_node.py
@@ -98,8 +98,7 @@ class DataCollectorNode(object):
 
     def imu_callback(self, data):
         if data.header.frame_id == 'imu_link':
-            #get the biggest z difference one of the ankles
-            z_diff = -2;
+            z_diff = -1000;
             old_z = self.tf_buffer.lookup_transform('world', 'imu_link', rospy.Time()).transform.translation.z
             for foot in self.feet:
                 trans = self.tf_buffer.lookup_transform('world', foot, rospy.Time())
@@ -172,7 +171,7 @@ def main():
     tf_buffer = tf2_ros.Buffer()
     tf2_ros.TransformListener(tf_buffer)
     center_of_mass_calculator = CoMCalculator(robot, tf_buffer)
-    feet = ['ankle_plate_left', 'ankle_plate_right']
+    feet = ['foot_left', 'foot_right']
     cp_calculators = [CPCalculator(tf_buffer, foot) for foot in feet]
     data_collector_node = DataCollectorNode(robot, center_of_mass_calculator, cp_calculators, tf_buffer, feet)
     data_collector_node.run()

--- a/march_data_collector/src/march_data_collector/data_collector_node.py
+++ b/march_data_collector/src/march_data_collector/data_collector_node.py
@@ -103,7 +103,7 @@ class DataCollectorNode(object):
     def imu_callback(self, data):
         if data.header.frame_id == 'imu_link':
 
-            z_diff = float("-inf")
+            z_diff = float('-inf')
             try:
                 old_z = self.tf_buffer.lookup_transform('world', 'imu_link', rospy.Time()).transform.translation.z
                 for foot in self.feet:


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-393

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
This makes sure that when the robot to world transform is made by the IMU that the correct height is set. The height is chosen such that the lowest foot is on the ground. This worked better then I expected, when I moved the IMU quite a lot, it felled really natural. The body still under the ground when you flip the IMU over but I think it does not makes sense the cover that situation, because if exo is upside down we have a lot bigger problems. 
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
* Changed the transformation calculated based on the IMU to take the height of the feet into account and place the exo on the ground. 
<!-- Please don't forget to request for reviews -->

## Testing
In the bag find there is some IMU data to test this.
