### PR TITLE
Solve the 'random' closing of the exoskeleton

### DIFF
--- a/march_state_machine/src/march_state_machine/states/idle_state.py
+++ b/march_state_machine/src/march_state_machine/states/idle_state.py
@@ -27,6 +27,8 @@ class IdleState(smach.State):
         self._result_gait = None
 
         control_flow.reset_gait()
+        control_flow.reset_stop()
+
         control_flow.set_stopped_callback(self._stopped_cb)
         control_flow.set_gait_transition_callback(self._transition_cb)
         control_flow.set_gait_selected_callback(self._gait_cb)


### PR DESCRIPTION
Closes PM-390

## Description
The reset variable was not reset if the left close or right close was being executed. This way the exoskeleton could 'randomly' stop in the next walking sequence. Resetting the stop every time the idle state is entered should solve this problem

## Changes
* Reset stop variable when idle state is entered