### PR TITLE
Feature/pm 391 set state machine to unknown

### DIFF
--- a/march_shared_resources/msg/GaitInstruction.msg
+++ b/march_shared_resources/msg/GaitInstruction.msg
@@ -4,6 +4,7 @@ Header header
 int8 type
 
 # All possible instruction types.
+int8 UNKNOWN = -1
 int8 STOP = 0
 int8 GAIT = 1
 int8 PAUSE = 2

--- a/march_state_machine/src/march_state_machine/control_flow.py
+++ b/march_state_machine/src/march_state_machine/control_flow.py
@@ -21,6 +21,7 @@ class ControlFlow:
         self._stopped_cb = None
         self._gait_selected_cb = None
         self._gait_transition_cb = None
+        self._set_sm_to_unknown_cb = None
 
     def clear_callbacks(self):
         """Clears all currently registered callbacks."""
@@ -48,6 +49,9 @@ class ControlFlow:
         :param cb: Callback that will be called when a transition is selected
         """
         self._gait_transition_cb = cb
+
+    def set_state_machine_to_unknown(self, cb):
+        self._set_sm_to_unknown_cb = cb
 
     def get_transition_integer(self):
         """Used to return the transition in the integer-format."""
@@ -127,6 +131,10 @@ class ControlFlow:
             self._transition_index = GaitInstruction.DECREMENT_STEP_SIZE
             if callable(self._gait_transition_cb):
                 self._gait_transition_cb()
+
+        if msg.type == GaitInstruction.UNKNOWN:
+            if callable(self._set_sm_to_unknown_cb):
+                self._set_sm_to_unknown_cb()
 
 
 control_flow = ControlFlow()

--- a/march_state_machine/src/march_state_machine/control_flow.py
+++ b/march_state_machine/src/march_state_machine/control_flow.py
@@ -28,6 +28,7 @@ class ControlFlow:
         self._stopped_cb = None
         self._gait_selected_cb = None
         self._gait_transition_cb = None
+        self._set_sm_to_unknown_cb = None
 
     def set_stopped_callback(self, cb):
         """Sets the callback for when stop is pressed.

--- a/march_state_machine/src/march_state_machine/gaits/slope_down_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/slope_down_sm.py
@@ -12,7 +12,8 @@ def create():
         smach.StateMachine.add('GAIT RD SLOPE DOWN', SlopeStateMachine('ramp_door_slope_down'),
                                transitions={'succeeded': 'STANDING SLOPE DOWN'})
 
-        smach.StateMachine.add('STANDING SLOPE DOWN', IdleState(outcomes=['gait_ramp_door_last_step', 'preempted']),
+        smach.StateMachine.add('STANDING SLOPE DOWN', IdleState(outcomes=['gait_ramp_door_last_step', 'preempted',
+                                                                          'failed']),
                                transitions={'gait_ramp_door_last_step': 'GAIT RD LAST STEP'})
 
         smach.StateMachine.add('GAIT RD LAST STEP', StepStateMachine('ramp_door_last_step'),

--- a/march_state_machine/src/march_state_machine/gaits/slope_down_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/slope_down_sm.py
@@ -12,8 +12,7 @@ def create():
         smach.StateMachine.add('GAIT RD SLOPE DOWN', SlopeStateMachine('ramp_door_slope_down'),
                                transitions={'succeeded': 'STANDING SLOPE DOWN'})
 
-        smach.StateMachine.add('STANDING SLOPE DOWN', IdleState(outcomes=['gait_ramp_door_last_step', 'preempted',
-                                                                          'failed']),
+        smach.StateMachine.add('STANDING SLOPE DOWN', IdleState(gait_outcomes=['gait_ramp_door_last_step']),
                                transitions={'gait_ramp_door_last_step': 'GAIT RD LAST STEP'})
 
         smach.StateMachine.add('GAIT RD LAST STEP', StepStateMachine('ramp_door_last_step'),

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_left_flexed_knee_step_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_left_flexed_knee_step_sm.py
@@ -17,9 +17,9 @@ def create():
                                transitions={'succeeded': 'STANDING TP LEFT STRAIGHT',
                                             'rejected': 'STANDING TP LEFT STRAIGHT'})
 
-        smach.StateMachine.add('STANDING TP LEFT STRAIGHT', IdleState(outcomes=['gait_tilted_path_left_single_step',
-                                                                                'gait_tilted_path_left_straight_end',
-                                                                                'preempted', 'failed']),
+        smach.StateMachine.add('STANDING TP LEFT STRAIGHT',
+                               IdleState(gait_outcomes=['gait_tilted_path_left_single_step',
+                                                        'gait_tilted_path_left_straight_end']),
                                transitions={'gait_tilted_path_left_single_step': 'GAIT TP LEFT SINGLE STEP',
                                             'gait_tilted_path_left_straight_end': 'GAIT TP LEFT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_left_flexed_knee_step_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_left_flexed_knee_step_sm.py
@@ -19,7 +19,7 @@ def create():
 
         smach.StateMachine.add('STANDING TP LEFT STRAIGHT', IdleState(outcomes=['gait_tilted_path_left_single_step',
                                                                                 'gait_tilted_path_left_straight_end',
-                                                                                'preempted']),
+                                                                                'preempted', 'failed']),
                                transitions={'gait_tilted_path_left_single_step': 'GAIT TP LEFT SINGLE STEP',
                                             'gait_tilted_path_left_straight_end': 'GAIT TP LEFT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_left_knee_bend_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_left_knee_bend_sm.py
@@ -6,10 +6,10 @@ from march_state_machine.states.idle_state import IdleState
 
 def create():
     sm_tilted_path_left_knee_bend = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
-    sm_tilted_path_left_knee_bend .register_io_keys(['sounds'])
+    sm_tilted_path_left_knee_bend.register_io_keys(['sounds'])
     with sm_tilted_path_left_knee_bend:
         smach.StateMachine.add('GAIT TP LEFT KNEE BEND', StepStateMachine('tilted_path_left_knee_bend',
-                               subgaits=['right_open']),
+                                                                          subgaits=['right_open']),
                                transitions={'succeeded': 'STANDING TP LEFT STRAIGHT'})
 
         smach.StateMachine.add('GAIT TP LEFT SINGLE STEP', StepStateMachine('tilted_path_left_single_step',
@@ -17,9 +17,9 @@ def create():
                                transitions={'succeeded': 'STANDING TP LEFT STRAIGHT',
                                             'rejected': 'STANDING TP LEFT STRAIGHT'})
 
-        smach.StateMachine.add('STANDING TP LEFT STRAIGHT', IdleState(outcomes=['gait_tilted_path_left_single_step',
-                                                                                'gait_tilted_path_left_straight_end',
-                                                                                'preempted']),
+        smach.StateMachine.add('STANDING TP LEFT STRAIGHT',
+                               IdleState(gait_outcomes=['gait_tilted_path_left_single_step',
+                                                        'gait_tilted_path_left_straight_end']),
                                transitions={'gait_tilted_path_left_single_step': 'GAIT TP LEFT SINGLE STEP',
                                             'gait_tilted_path_left_straight_end': 'GAIT TP LEFT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_left_straight_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_left_straight_sm.py
@@ -17,9 +17,9 @@ def create():
                                transitions={'succeeded': 'STANDING TP LEFT STRAIGHT',
                                             'rejected': 'STANDING TP LEFT STRAIGHT'})
 
-        smach.StateMachine.add('STANDING TP LEFT STRAIGHT', IdleState(outcomes=['gait_tilted_path_left_single_step',
-                                                                                'gait_tilted_path_left_straight_end',
-                                                                                'preempted', 'failed']),
+        smach.StateMachine.add('STANDING TP LEFT STRAIGHT',
+                               IdleState(gait_outcomes=['gait_tilted_path_left_single_step',
+                                                        'gait_tilted_path_left_straight_end']),
                                transitions={'gait_tilted_path_left_single_step': 'GAIT TP LEFT SINGLE STEP',
                                             'gait_tilted_path_left_straight_end': 'GAIT TP LEFT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_left_straight_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_left_straight_sm.py
@@ -19,7 +19,7 @@ def create():
 
         smach.StateMachine.add('STANDING TP LEFT STRAIGHT', IdleState(outcomes=['gait_tilted_path_left_single_step',
                                                                                 'gait_tilted_path_left_straight_end',
-                                                                                'preempted']),
+                                                                                'preempted', 'failed']),
                                transitions={'gait_tilted_path_left_single_step': 'GAIT TP LEFT SINGLE STEP',
                                             'gait_tilted_path_left_straight_end': 'GAIT TP LEFT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_right_flexed_knee_step_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_right_flexed_knee_step_sm.py
@@ -21,7 +21,7 @@ def create():
 
         smach.StateMachine.add('STANDING TP RIGHT STRAIGHT', IdleState(outcomes=['gait_tilted_path_right_single_step',
                                                                                  'gait_tilted_path_right_straight_end',
-                                                                                 'preempted']),
+                                                                                 'preempted', 'failed']),
                                transitions={'gait_tilted_path_right_single_step': 'GAIT TP RIGHT SINGLE STEP',
                                             'gait_tilted_path_right_straight_end': 'GAIT TP RIGHT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_right_flexed_knee_step_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_right_flexed_knee_step_sm.py
@@ -19,9 +19,9 @@ def create():
                                transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT',
                                             'rejected': 'STANDING TP RIGHT STRAIGHT'})
 
-        smach.StateMachine.add('STANDING TP RIGHT STRAIGHT', IdleState(outcomes=['gait_tilted_path_right_single_step',
-                                                                                 'gait_tilted_path_right_straight_end',
-                                                                                 'preempted', 'failed']),
+        smach.StateMachine.add('STANDING TP RIGHT STRAIGHT',
+                               IdleState(gait_outcomes=['gait_tilted_path_right_single_step',
+                                                        'gait_tilted_path_right_straight_end']),
                                transitions={'gait_tilted_path_right_single_step': 'GAIT TP RIGHT SINGLE STEP',
                                             'gait_tilted_path_right_straight_end': 'GAIT TP RIGHT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_right_straight_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_right_straight_sm.py
@@ -19,7 +19,7 @@ def create():
 
         smach.StateMachine.add('STANDING TP RIGHT STRAIGHT', IdleState(outcomes=['gait_tilted_path_right_single_step',
                                                                                  'gait_tilted_path_right_straight_end',
-                                                                                 'preempted']),
+                                                                                 'preempted', 'failed']),
                                transitions={'gait_tilted_path_right_single_step': 'GAIT TP RIGHT SINGLE STEP',
                                             'gait_tilted_path_right_straight_end': 'GAIT TP RIGHT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_right_straight_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_right_straight_sm.py
@@ -17,9 +17,9 @@ def create():
                                transitions={'succeeded': 'STANDING TP RIGHT STRAIGHT',
                                             'rejected': 'STANDING TP RIGHT STRAIGHT'})
 
-        smach.StateMachine.add('STANDING TP RIGHT STRAIGHT', IdleState(outcomes=['gait_tilted_path_right_single_step',
-                                                                                 'gait_tilted_path_right_straight_end',
-                                                                                 'preempted', 'failed']),
+        smach.StateMachine.add('STANDING TP RIGHT STRAIGHT',
+                               IdleState(gait_outcomes=['gait_tilted_path_right_single_step',
+                                                        'gait_tilted_path_right_straight_end']),
                                transitions={'gait_tilted_path_right_single_step': 'GAIT TP RIGHT SINGLE STEP',
                                             'gait_tilted_path_right_straight_end': 'GAIT TP RIGHT STRAIGHT END'})
 

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
@@ -12,8 +12,7 @@ def create():
                                                                      subgaits=['left_open', 'right_close']),
                                transitions={'succeeded': 'STANDING TP SIDEWAYS END'})
 
-        smach.StateMachine.add('STANDING TP SIDEWAYS END', IdleState(outcomes=['gait_tilted_path_second_end',
-                                                                               'preempted', 'failed']),
+        smach.StateMachine.add('STANDING TP SIDEWAYS END', IdleState(gait_outcomes=['gait_tilted_path_second_end']),
                                transitions={'gait_tilted_path_second_end': 'GAIT TP SECOND END'})
 
         smach.StateMachine.add('GAIT TP SECOND END', StepStateMachine('tilted_path_second_end',

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_end_sm.py
@@ -13,7 +13,7 @@ def create():
                                transitions={'succeeded': 'STANDING TP SIDEWAYS END'})
 
         smach.StateMachine.add('STANDING TP SIDEWAYS END', IdleState(outcomes=['gait_tilted_path_second_end',
-                                                                               'preempted']),
+                                                                               'preempted', 'failed']),
                                transitions={'gait_tilted_path_second_end': 'GAIT TP SECOND END'})
 
         smach.StateMachine.add('GAIT TP SECOND END', StepStateMachine('tilted_path_second_end',

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
@@ -12,8 +12,7 @@ def create():
                                                                        subgaits=['left_open', 'right_close']),
                                transitions={'succeeded': 'STANDING TP SIDEWAYS START'})
 
-        smach.StateMachine.add('STANDING TP SIDEWAYS START', IdleState(outcomes=['gait_tilted_path_second_start',
-                                                                                 'preempted', 'failed']),
+        smach.StateMachine.add('STANDING TP SIDEWAYS START', IdleState(gait_outcomes=['gait_tilted_path_second_start']),
                                transitions={'gait_tilted_path_second_start': 'GAIT TP SECOND START'})
 
         smach.StateMachine.add('GAIT TP SECOND START', StepStateMachine('tilted_path_second_start',

--- a/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/tilted_path_sideways_start_sm.py
@@ -13,7 +13,7 @@ def create():
                                transitions={'succeeded': 'STANDING TP SIDEWAYS START'})
 
         smach.StateMachine.add('STANDING TP SIDEWAYS START', IdleState(outcomes=['gait_tilted_path_second_start',
-                                                                                 'preempted']),
+                                                                                 'preempted', 'failed']),
                                transitions={'gait_tilted_path_second_start': 'GAIT TP SECOND START'})
 
         smach.StateMachine.add('GAIT TP SECOND START', StepStateMachine('tilted_path_second_start',

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -50,7 +50,7 @@ class HealthyStateMachine(smach.StateMachine):
         self.open()
         self.add_auto('START', HealthyStart(), connector_outcomes=['succeeded'])
         self.add('UNKNOWN', IdleState(outcomes=['home_sit', 'home_stand', 'failed', 'preempted']),
-                 transitions={'home_sit': 'HOME SIT', 'home_stand': 'HOME STAND'})
+                 transitions={'home_sit': 'HOME SIT', 'home_stand': 'HOME STAND', 'failed': 'UNKNOWN'})
 
         self.add_state('HOME SIT', StepStateMachine('home', ['home_sit']), 'SITTING', rejected='UNKNOWN')
         self.add_state('HOME STAND', StepStateMachine('home', ['home_stand']), 'STANDING', rejected='UNKNOWN')

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -49,7 +49,7 @@ class HealthyStateMachine(smach.StateMachine):
 
         self.open()
         self.add_auto('START', HealthyStart(), connector_outcomes=['succeeded'])
-        self.add('UNKNOWN', IdleState(outcomes=['home_sit', 'home_stand', 'failed', 'preempted']),
+        self.add('UNKNOWN', IdleState(gait_outcomes=['home_sit', 'home_stand']),
                  transitions={'home_sit': 'HOME SIT', 'home_stand': 'HOME STAND', 'failed': 'UNKNOWN'})
 
         self.add_state('HOME SIT', StepStateMachine('home', ['home_sit']), 'SITTING', rejected='UNKNOWN')
@@ -83,8 +83,8 @@ class HealthyStateMachine(smach.StateMachine):
 
         self.add_state('GAIT SOFA SIT', StepStateMachine('sofa_sit', ['sit_down', 'sit_home']), 'SOFA SITTING',
                        rejected='STANDING')
-        self.add('SOFA SITTING', IdleState(outcomes=['gait_sofa_stand', 'preempted']),
-                 transitions={'gait_sofa_stand': 'GAIT SOFA STAND'})
+        self.add('SOFA SITTING', IdleState(gait_outcomes=['gait_sofa_stand']),
+                 transitions={'gait_sofa_stand': 'GAIT SOFA STAND', 'failed': 'UNKNOWN'})
         self.add_state('GAIT SOFA STAND', StepStateMachine('sofa_stand', ['prepare_stand_up', 'stand_up']), 'STANDING',
                        rejected='SOFA SITTING')
 
@@ -119,27 +119,27 @@ class HealthyStateMachine(smach.StateMachine):
         self.add_state('GAIT TP SIDEWAYS START', tilted_path_sideways_start_sm.create(), 'STANDING')
         self.add_state('GAIT TP SIDEWAYS END', tilted_path_sideways_end_sm.create(), 'STANDING')
 
-        self.add('SITTING', IdleState(outcomes=['gait_stand', 'preempted', 'failed']),
+        self.add('SITTING', IdleState(gait_outcomes=['gait_stand']),
                  transitions={'gait_stand': 'GAIT STAND', 'failed': 'UNKNOWN'})
-        self.add('STANDING', IdleState(outcomes=['gait_sit', 'gait_walk', 'gait_walk_small', 'gait_single_step_small',
-                                                 'gait_walk_large', 'gait_single_step_normal', 'gait_side_step_left',
-                                                 'gait_side_step_right', 'gait_side_step_left_small',
-                                                 'gait_side_step_right_small', 'gait_sofa_sit',
-                                                 'gait_stairs_up', 'gait_stairs_down',
-                                                 'gait_stairs_up_single_step', 'gait_stairs_down_single_step',
-                                                 'gait_walk_small', 'gait_rough_terrain_high_step',
-                                                 'gait_rough_terrain_middle_steps',
-                                                 'gait_rough_terrain_first_middle_step',
-                                                 'gait_rough_terrain_second_middle_step',
-                                                 'gait_rough_terrain_third_middle_step',
-                                                 'gait_ramp_door_slope_up', 'gait_ramp_door_slope_down',
-                                                 'gait_tilted_path_left_straight_start',
-                                                 'gait_tilted_path_left_flexed_knee_step',
-                                                 'gait_tilted_path_right_straight_start',
-                                                 'gait_tilted_path_right_flexed_knee_step',
-                                                 'gait_tilted_path_first_start',
-                                                 'gait_tilted_path_first_end',
-                                                 'preempted', 'failed']),
+        self.add('STANDING', IdleState(gait_outcomes=['gait_sit', 'gait_walk', 'gait_walk_small',
+                                                      'gait_single_step_small', 'gait_walk_large',
+                                                      'gait_single_step_normal', 'gait_side_step_left',
+                                                      'gait_side_step_right', 'gait_side_step_left_small',
+                                                      'gait_side_step_right_small', 'gait_sofa_sit',
+                                                      'gait_stairs_up', 'gait_stairs_down',
+                                                      'gait_stairs_up_single_step', 'gait_stairs_down_single_step',
+                                                      'gait_walk_small', 'gait_rough_terrain_high_step',
+                                                      'gait_rough_terrain_middle_steps',
+                                                      'gait_rough_terrain_first_middle_step',
+                                                      'gait_rough_terrain_second_middle_step',
+                                                      'gait_rough_terrain_third_middle_step',
+                                                      'gait_ramp_door_slope_up', 'gait_ramp_door_slope_down',
+                                                      'gait_tilted_path_left_straight_start',
+                                                      'gait_tilted_path_left_flexed_knee_step',
+                                                      'gait_tilted_path_right_straight_start',
+                                                      'gait_tilted_path_right_flexed_knee_step',
+                                                      'gait_tilted_path_first_start',
+                                                      'gait_tilted_path_first_end']),
                  transitions={'gait_sit': 'GAIT SIT',
                               'gait_walk': 'GAIT WALK',
                               'gait_walk_small': 'GAIT WALK SMALL',

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -119,8 +119,8 @@ class HealthyStateMachine(smach.StateMachine):
         self.add_state('GAIT TP SIDEWAYS START', tilted_path_sideways_start_sm.create(), 'STANDING')
         self.add_state('GAIT TP SIDEWAYS END', tilted_path_sideways_end_sm.create(), 'STANDING')
 
-        self.add('SITTING', IdleState(outcomes=['gait_stand', 'preempted']),
-                 transitions={'gait_stand': 'GAIT STAND'})
+        self.add('SITTING', IdleState(outcomes=['gait_stand', 'preempted', 'failed']),
+                 transitions={'gait_stand': 'GAIT STAND', 'failed': 'UNKNOWN'})
         self.add('STANDING', IdleState(outcomes=['gait_sit', 'gait_walk', 'gait_walk_small', 'gait_single_step_small',
                                                  'gait_walk_large', 'gait_single_step_normal', 'gait_side_step_left',
                                                  'gait_side_step_right', 'gait_side_step_left_small',
@@ -139,7 +139,7 @@ class HealthyStateMachine(smach.StateMachine):
                                                  'gait_tilted_path_right_flexed_knee_step',
                                                  'gait_tilted_path_first_start',
                                                  'gait_tilted_path_first_end',
-                                                 'preempted']),
+                                                 'preempted', 'failed']),
                  transitions={'gait_sit': 'GAIT SIT',
                               'gait_walk': 'GAIT WALK',
                               'gait_walk_small': 'GAIT WALK SMALL',
@@ -167,7 +167,8 @@ class HealthyStateMachine(smach.StateMachine):
                               'gait_tilted_path_right_straight_start': 'GAIT TP RIGHT STRAIGHT',
                               'gait_tilted_path_right_flexed_knee_step': 'GAIT TP RIGHT FLEXED KNEE STEP',
                               'gait_tilted_path_first_start': 'GAIT TP SIDEWAYS START',
-                              'gait_tilted_path_first_end': 'GAIT TP SIDEWAYS END'})
+                              'gait_tilted_path_first_end': 'GAIT TP SIDEWAYS END',
+                              'failed': 'UNKNOWN'})
         self.close()
 
     def add_state(self, label, state, succeeded, rejected=None, custom_start_label=None):

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -123,8 +123,8 @@ class HealthyStateMachine(smach.StateMachine):
 
         self.add('SITTING', IdleState(gait_outcomes=['gait_stand']),
                  transitions={'gait_stand': 'GAIT STAND', 'failed': 'UNKNOWN'})
-        self.add('STANDING', IdleState(gait_outcomes=['gait_sit', 'gait_walk', 'gait_walk_small', 
-                                                      'gait_single_step_small','gait_walk_large', 
+        self.add('STANDING', IdleState(gait_outcomes=['gait_sit', 'gait_walk', 'gait_walk_small',
+                                                      'gait_single_step_small', 'gait_walk_large',
                                                       'gait_single_step_normal', 'gait_side_step_left',
                                                       'gait_side_step_right', 'gait_side_step_left_small',
                                                       'gait_side_step_right_small', 'gait_sofa_sit',

--- a/march_state_machine/src/march_state_machine/states/idle_state.py
+++ b/march_state_machine/src/march_state_machine/states/idle_state.py
@@ -27,9 +27,11 @@ class IdleState(smach.State):
         self._result_gait = None
 
         control_flow.reset_gait()
+
         control_flow.set_stopped_callback(self._stopped_cb)
         control_flow.set_gait_transition_callback(self._transition_cb)
         control_flow.set_gait_selected_callback(self._gait_cb)
+        control_flow.set_state_machine_to_unknown(self._return_failed)
 
         self._trigger_event.wait()
         control_flow.clear_callbacks()
@@ -65,4 +67,9 @@ class IdleState(smach.State):
 
     def request_preempt(self):
         super(IdleState, self).request_preempt()
+        self._trigger_event.set()
+
+    def _return_failed(self):
+        rospy.logwarn('Current state is set to unknown.')
+        self._result_gait = None
         self._trigger_event.set()

--- a/march_state_machine/src/march_state_machine/states/idle_state.py
+++ b/march_state_machine/src/march_state_machine/states/idle_state.py
@@ -12,7 +12,8 @@ class IdleState(smach.State):
     Listens to instructions from the input device and reacts if they are known transitions.
     """
 
-    def __init__(self, outcomes):
+    def __init__(self, gait_outcomes):
+        outcomes = ['failed', 'preempted'] + gait_outcomes
         super(IdleState, self).__init__(outcomes)
 
         self._result_gait = None


### PR DESCRIPTION

Closes PM-391
(Also use the feature/PM-391-sm-to-unknown-button in the march_rqt_input_device)

## Description
This PR solves the problem to shutdown the exoskeleton in order to home-stand of home-sit again. It does this by manually setting the state to the 'UNKNOWN' state in the exoskeleton. It is only useful to have this callback in the idle_state because this state is used in the side and ramp up gaits. In order to move to the 'UNKNOWN' state the 'failed' outcome is used for every idle state and has been added if it was not available yet

## Changes
* At UNKNOWN instruction to the GaitInstruction.msg
* Added a callback method in the control_flow.py
* Added the 'failed' and transition to UNKNOWN tag
* Used the callback in the idle_state
