### PR TITLE
Fix namespace issue when launching the moveit package. 

### DIFF
--- a/march_launch/launch/march.launch
+++ b/march_launch/launch/march.launch
@@ -48,7 +48,7 @@
         <include file="$(find march_state_machine)/launch/state_machine.launch">
             <arg name="state_machine_viewer" value="$(eval not headless and state_machine_viewer)"/>
             <arg name="unpause" value="$(eval configuration == 'simulation' and unpause)"/>
-            <arg name="sounds" value="$(arg sounds)"/>
+            <arg name="sounds" value="$(arg sounds)"/>		
         </include>
 
         <include file="$(find march_safety)/launch/march_safety.launch"/>
@@ -74,6 +74,8 @@
             <arg name="pressure_soles" value="$(arg pressure_soles)"/>
             <arg name="moticon_ip" value="$(arg moticon_ip)"/>
         </include>
+
+    	<include if="$(arg balance)" file="$(find march_moveit)/launch/march_moveit.launch" />
     </group>
 
     <group if="$(eval configuration == 'exoskeleton')">

--- a/march_launch/launch/march_simulation.launch
+++ b/march_launch/launch/march_simulation.launch
@@ -24,6 +24,4 @@
     <include file="$(dirname)/march.launch" pass_all_args="true">
         <arg name="configuration" value="simulation"/>
     </include>
-
-    <include if="$(arg balance)" file="$(find march_moveit)/launch/march_moveit.launch" />
 </launch>


### PR DESCRIPTION

## Description
There was a namespace issue because the moveit package was not included within the march namespace inside the march.launch. It is also more logical to include a launch file in the march.launch since all the other launch files are also located here.  

## Changes
* Moved the march_moveit launch to the march.launch file
* removed the march_moveit launch from the march_simulation.launch file 
