### PR TITLE
Feature: add alive msg

### DIFF
--- a/march_shared_resources/CMakeLists.txt
+++ b/march_shared_resources/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(
     FILES
     AfterLimitJointCommand.msg
+    Alive.msg
     Error.msg
     GaitInstruction.msg
     GaitInstructionResponse.msg

--- a/march_shared_resources/msg/Alive.msg
+++ b/march_shared_resources/msg/Alive.msg
@@ -1,0 +1,9 @@
+# Message type that is used by input devices to signal they are still alive.
+
+# Timestamp at which the input device was last alive
+time stamp
+
+# Unique identifier used to identify an input device when connection has been lost.
+# The id should be readable and you should be able to tell from what machine and
+# what type of input device it originates.
+string id

--- a/march_shared_resources/msg/GaitInstruction.msg
+++ b/march_shared_resources/msg/GaitInstruction.msg
@@ -15,3 +15,5 @@ int8 DECREMENT_STEP_SIZE = 5
 # If the type is a GAIT this is the name of the gait.
 string gait_name
 
+# Unique identifier for the input device sending this message. See `Alive`.
+string id


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

First step of PM-446

## Description
This PR adds an `Alive` msg, which contains a timestamp and identifier. Previously, there existed no such message and `Time` was just used. I added a comment, which describes what an id should be. I'm open to suggestions about what this field should contain.

I have also looked into other ways of identifying input devices. Using the node name seemed like a good idea, since these are always unique and no extra messages are necessary. However, the way in which you would have to retrieve this name is [_brittle_](https://answers.ros.org/question/10346/how-to-get-the-publisher-name-from-a-received-message-in-rospy/?answer=15240#post-id-15240).

Personally, I find the `Alive` message a nice way, since you can directly see who and what sent the message, also programmatically.

## Changes
* Added `Alive.msg`
* Added `id` to `GaitInstruction.msg`

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
