### PR TITLE
Set the load robot description argument to default false

### DIFF
--- a/march_moveit/launch/move_group.launch
+++ b/march_moveit/launch/move_group.launch
@@ -37,7 +37,7 @@
                 " />
   -->
 
-  <arg name="load_robot_description" default="true" />
+  <arg name="load_robot_description" default="false" />
   <!-- load URDF, SRDF and joint_limits configuration -->
   <include file="$(find march_moveit)/launch/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />


### PR DESCRIPTION

## Description
When using the moveit package (with the balance argument set to true) the robot_description parameter was set by default in the moveit launch file. In combination with the simulation model a problem occurred. The march_world.launch sets a few variables to the robot description before setting the parameter to the ROS server. Since moveit launched the parameter in his own launch file the changes set by the march simulation launch were not received in the moveit package. 

By setting the default value of load_robot_description in the moveit launch file to false the robot_description used in the simulation model is also used in the moveit package. 