### PR TITLE
Feature: add arduino master to launch

### DIFF
--- a/march_launch/launch/march.launch
+++ b/march_launch/launch/march.launch
@@ -16,7 +16,8 @@
     <arg name="unpause" default="true" doc="Unpause simulation when controller starts."/>
     <arg name="fixed" default="true" doc="Fixes the exoskeleton in the world in rviz"/>
 
-    <arg name="input-device" default="false" doc="Launches ros serial node to connect with input device."/>
+    <arg name="arduino_master" default="false" doc="Launches ros serial node to connect with arduino on master."/>
+    <arg name="input_device" default="false" doc="Launches ros serial node to connect with input device."/>
     <arg name="wireless" default="false" doc="Enables wireless connection to the input device."/>
 
     <arg name="gait_directory" default="training-v" doc="Gait files directory to use"/>
@@ -94,8 +95,9 @@
         </include>
     </group>
 
-    <include file="$(dirname)/serial_connection.launch" if="$(arg input-device)">
+    <include file="$(dirname)/serial_connection.launch">
+        <arg name="arduino_master" value="$(arg arduino_master)"/>
+        <arg name="input_device" value="$(arg input_device)"/>
         <arg name="wireless" value="$(arg wireless)"/>
     </include>
-
 </launch>

--- a/march_launch/launch/march_headless.launch
+++ b/march_launch/launch/march_headless.launch
@@ -4,6 +4,7 @@
     <arg name="gain_tuning" default="sjaan_gait" doc="The configuration to use for gain scheduling. Only used when 'gain_scheduling' is true."/>
     <arg name="sounds" default="true" doc="Whether to use sounds."/>
 
+    <arg name="arduino_master" default="true" doc="Launches ros serial node to connect with arduino on master."/>
     <arg name="input-device" default="true" doc="Launches ros serial node to connect with input device."/>
     <arg name="wireless" default="false" doc="Enables wireless connection to the input device."/>
 

--- a/march_launch/launch/serial_connection.launch
+++ b/march_launch/launch/serial_connection.launch
@@ -1,9 +1,21 @@
 <launch>
+    <arg name="arduino_master" default="true" doc="Launches the arduino master serial node when true."/>
+    <arg name="arduino_master_port" default="/dev/ttyACM0" doc="Device port to use for arduino master serial connection."/>
+    <arg name="arduino_master_baud" default="57600" doc="Baud rate to set for the arduino master connection."/>
+
+    <arg name="input_device" default="true" doc="Launches the input device serial node when true."/>
+    <arg name="input_device_port" default="/dev/ttyUSB0" doc="Device port to use for input device serial connection. Only used when `wireless` is false."/>
+    <arg name="arduino_master_baud" default="57600" doc="Baud rate to set for the input device connection. Only used when `wireless` is false."/>
     <arg name="wireless" default="false" doc="Use wireless connection to input device. Defaults to false."/>
 
-    <node pkg="rosserial_python" type="serial_node.py" name="serial_node">
+    <node name="arduino_master" pkg="rosserial_python" type="serial_node.py" if="$(arg arduino_master)">
+        <param name="port" value="$(arg arduino_master_port)"/>
+        <param name="baud" value="$(arg arduino_master_baud)"/>
+    </node>
+
+    <node name="input_device" pkg="rosserial_python" type="serial_node.py" if="$(arg input_device)">
         <param name="port" value="tcp" if="$(arg wireless)"/>
-        <param name="port" value="/dev/ttyUSB0" unless="$(arg wireless)"/>
-        <param name="baud" value="57600" unless="$(arg wireless)"/>
+        <param name="port" value="$(arg input_device_port)" unless="$(arg wireless)"/>
+        <param name="baud" value="$(arg input_device_baud)" unless="$(arg wireless)"/>
     </node>
 </launch>

--- a/march_launch/launch/serial_connection.launch
+++ b/march_launch/launch/serial_connection.launch
@@ -5,7 +5,7 @@
 
     <arg name="input_device" default="true" doc="Launches the input device serial node when true."/>
     <arg name="input_device_port" default="/dev/ttyUSB0" doc="Device port to use for input device serial connection. Only used when `wireless` is false."/>
-    <arg name="arduino_master_baud" default="57600" doc="Baud rate to set for the input device connection. Only used when `wireless` is false."/>
+    <arg name="input_device_baud" default="57600" doc="Baud rate to set for the input device connection. Only used when `wireless` is false."/>
     <arg name="wireless" default="false" doc="Use wireless connection to input device. Defaults to false."/>
 
     <node name="arduino_master" pkg="rosserial_python" type="serial_node.py" if="$(arg arduino_master)">


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
I noticed that I forgot to add the serial connection with the embedded Arduino on the master to the launch files. I have added the node to `serial_connection.launch`, which seemed like a suitable location for it.

## Changes
* Add `arduino_master` node launching
* Add `arduino_master` option to `march_launch` and `march_headless.launch`

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
