### PR TITLE
Add support for multiple ipd connections in safety

### DIFF
--- a/march_safety/include/march_safety/input_device_safety.h
+++ b/march_safety/include/march_safety/input_device_safety.h
@@ -1,15 +1,17 @@
 // Copyright 2019 Project March
 #ifndef MARCH_SAFETY_INPUT_DEVICE_SAFETY_H
 #define MARCH_SAFETY_INPUT_DEVICE_SAFETY_H
-
-#include <ros/ros.h>
-#include <std_msgs/Time.h>
-#include <sstream>
-
-#include <march_shared_resources/Error.h>
-
 #include "march_safety/safety_type.h"
 #include "march_safety/safety_handler.h"
+
+#include <ros/ros.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <march_shared_resources/Alive.h>
+#include <march_shared_resources/Error.h>
 
 class InputDeviceSafety : public SafetyType
 {
@@ -19,15 +21,16 @@ public:
   void update(const ros::Time& now) override;
 
 private:
-  void inputDeviceAliveCallback(const std_msgs::TimeConstPtr& msg);
+  void inputDeviceAliveCallback(const march_shared_resources::AliveConstPtr& msg);
 
   SafetyHandler* safety_handler_;
 
   ros::Subscriber subscriber_input_device_alive_;
 
   ros::Duration connection_timeout_;
-  ros::Time time_last_alive_;
-  bool is_connected_;
+
+  std::unordered_map<std::string, ros::Time> last_alive_stamps_;
+  std::unordered_set<std::string> connected_devices_;
 };
 
 #endif  // MARCH_SAFETY_INPUT_DEVICE_SAFETY_H

--- a/march_safety/src/input_device_safety.cpp
+++ b/march_safety/src/input_device_safety.cpp
@@ -28,10 +28,10 @@ void InputDeviceSafety::update(const ros::Time& now)
 
   const bool had_connections = !this->connected_devices_.empty();
 
-  for (const auto& entry : this->last_alive_stamps_)
+  for (const auto& last_alive_stamp : this->last_alive_stamps_)
   {
-    const std::string& id = entry.first;
-    const ros::Time& last_alive = entry.second;
+    const std::string& id = last_alive_stamp.first;
+    const ros::Time& last_alive = last_alive_stamp.second;
     const bool timed_out = now > (last_alive + this->connection_timeout_);
     const bool is_connected = this->connected_devices_.find(id) != this->connected_devices_.end();
 

--- a/march_safety/test/rostest/connection_lost_test.cpp
+++ b/march_safety/test/rostest/connection_lost_test.cpp
@@ -3,17 +3,12 @@
 #include "gtest/gtest.h"
 #include "ros/ros.h"
 #include <iostream>
-#include <std_msgs/Time.h>
 
 #include <march_safety/temperature_safety.h>
+#include <march_shared_resources/Alive.h>
 #include "error_counter.h"
 
-class TestConnectionLost : public ::testing::Test
-{
-protected:
-};
-
-TEST_F(TestConnectionLost, connectionLost)
+TEST(TestConnectionLost, connectionLost)
 {
   ros::Time::init();
   ros::NodeHandle nh;
@@ -23,7 +18,7 @@ TEST_F(TestConnectionLost, connectionLost)
   double send_errors_interval;
   nh.getParam("/march_safety_node/send_errors_interval", send_errors_interval);
 
-  ros::Publisher pub_alive = nh.advertise<std_msgs::Time>("march/input_device/alive", 0);
+  ros::Publisher pub_alive = nh.advertise<march_shared_resources::Alive>("march/input_device/alive", 0);
   ErrorCounter errorCounter;
   ros::Subscriber sub = nh.subscribe("march/error", 0, &ErrorCounter::cb, &errorCounter);
 
@@ -34,9 +29,10 @@ TEST_F(TestConnectionLost, connectionLost)
   EXPECT_EQ(1u, pub_alive.getNumSubscribers());
   EXPECT_EQ(1u, sub.getNumPublishers());
 
-  std_msgs::Time timeMessage;
-  timeMessage.data = ros::Time::now();
-  pub_alive.publish(timeMessage);
+  march_shared_resources::Alive msg;
+  msg.stamp = ros::Time::now();
+  msg.id = "test";
+  pub_alive.publish(msg);
   ros::spinOnce();
   double sleep_ms = send_errors_interval * 0.9 + input_device_connection_timeout;
   ros::Duration(sleep_ms / 1000).sleep();

--- a/march_safety/test/rostest/connection_never_started_test.cpp
+++ b/march_safety/test/rostest/connection_never_started_test.cpp
@@ -8,12 +8,7 @@
 #include <march_safety/temperature_safety.h>
 #include "error_counter.h"
 
-class TestConnectionNeverStarted : public ::testing::Test
-{
-protected:
-};
-
-TEST_F(TestConnectionNeverStarted, connectionNeverStarted)
+TEST(TestConnectionNeverStarted, connectionNeverStarted)
 {
   ros::Time::init();
   ros::NodeHandle nh;

--- a/march_safety/test/rostest/connection_not_lost_test.cpp
+++ b/march_safety/test/rostest/connection_not_lost_test.cpp
@@ -6,20 +6,16 @@
 #include <std_msgs/Time.h>
 
 #include <march_safety/temperature_safety.h>
+#include <march_shared_resources/Alive.h>
 #include "error_counter.h"
 
-class TestConnectionNotLost : public ::testing::Test
-{
-protected:
-};
-
-TEST_F(TestConnectionNotLost, connectionNotLost)
+TEST(TestConnectionNotLost, connectionNotLost)
 {
   ros::Time::init();
   ros::NodeHandle nh;
   double send_errors_interval;
   nh.getParam("/march_safety_node/send_errors_interval", send_errors_interval);
-  ros::Publisher pub_alive = nh.advertise<std_msgs::Time>("march/input_device/alive", 0);
+  ros::Publisher pub_alive = nh.advertise<march_shared_resources::Alive>("march/input_device/alive", 0);
   ErrorCounter errorCounter;
   ros::Subscriber sub = nh.subscribe("march/error", 0, &ErrorCounter::cb, &errorCounter);
 
@@ -30,9 +26,10 @@ TEST_F(TestConnectionNotLost, connectionNotLost)
   EXPECT_EQ(1u, pub_alive.getNumSubscribers());
   EXPECT_EQ(1u, sub.getNumPublishers());
 
-  std_msgs::Time timeMessage;
-  timeMessage.data = ros::Time::now();
-  pub_alive.publish(timeMessage);
+  march_shared_resources::Alive msg;
+  msg.stamp = ros::Time::now();
+  msg.id = "test";
+  pub_alive.publish(msg);
   ros::spinOnce();
   ros::Duration(send_errors_interval / 2 / 1000).sleep();
   ros::spinOnce();


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-446

## Description
This PR adds functionality in the safety node to support multiple input devices, with the use of the new `Alive` message. A log message is shown when a new input device (re)connects or loses connection. When there previously were input devices and at some point no more, then a single non fatal error is published.

```
[ INFO] Input device `100` reconnected. Total connected is 1
[ INFO] Input device `81` reconnected. Total connected is 2
[ WARN] Input device `100` lost
[ WARN] Input device `81` lost
[ERROR] All input devices are lost
[ INFO] No input device connected
```
(Ignore the random ints as names here, these are just for testing purposes)
## Changes
* Add subscribing with `Alive` msg
* Add a map and a set for keeping track of last alive times of all input devices and all connected input devices

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
