### PR TITLE
Fix: melodic compatible noetic changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ docs/build/*
 # qcreator stuff
 CMakeLists.txt.user
 
+*.egg-info/
 srv/_*.py
 *.pcd
 *.pyc
@@ -51,6 +52,7 @@ qtcreator-*
 
 # Catkin custom files
 CATKIN_IGNORE
+COLCON_IGNORE
 
 install/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - BUILDER=colcon
     - CATKIN_LINT=pedantic
+    - CATKIN_LINT_ARGS='--ignore launch_depend'
     # DEBIAN_FRONTEND disables interactive frontends when installing packages. This is necessary for tzdata.
     - DOCKER_RUN_OPTS='-e DEBIAN_FRONTEND=noninteractive'
     - DOWNSTREAM_WORKSPACE=.rosinstall

--- a/march_data_collector/CMakeLists.txt
+++ b/march_data_collector/CMakeLists.txt
@@ -5,12 +5,9 @@ find_package(catkin REQUIRED COMPONENTS
     control_msgs
     geometry_msgs
     march_shared_resources
-    rospy
     sensor_msgs
     std_msgs
-    tf
     tf2_geometry_msgs
-    tf2_ros
     visualization_msgs
 )
 
@@ -20,7 +17,7 @@ catkin_package(
     CATKIN_DEPENDS
     control_msgs
     geometry_msgs
-    rospy
+    march_shared_resources
     sensor_msgs
     std_msgs
     tf2_geometry_msgs

--- a/march_data_collector/CMakeLists.txt
+++ b/march_data_collector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_data_collector)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/march_data_collector/package.xml
+++ b/march_data_collector/package.xml
@@ -7,6 +7,7 @@
   <license>TODO</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python3-setuptools</buildtool_depend>
 
   <depend>rospy</depend>
   <depend>sensor_msgs</depend>

--- a/march_data_collector/package.xml
+++ b/march_data_collector/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_data_collector</name>
   <version>0.0.0</version>
   <description>Collecting data for further processing including sending to an Events Stream Processing engine</description>

--- a/march_data_collector/package.xml
+++ b/march_data_collector/package.xml
@@ -9,15 +9,15 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>python3-setuptools</buildtool_depend>
 
-  <depend>rospy</depend>
+  <depend>control_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>march_shared_resources</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>control_msgs</depend>
-  <depend>march_shared_resources</depend>
-  <depend>tf</depend>
-  <depend>tf2_ros</depend>
-  <depend>geometry_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
 
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf</exec_depend>
 </package>

--- a/march_data_collector/setup.py
+++ b/march_data_collector/setup.py
@@ -1,11 +1,10 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+from catkin_pkg.python_setup import generate_distutils_setup
 from setuptools import setup
 
-from catkin_pkg.python_setup import generate_distutils_setup
-
-# fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['march_data_collector'],
+    package_dir={'': 'src'},
     scripts=['scripts/march_data_collector'],
 )
 

--- a/march_data_collector/setup.py
+++ b/march_data_collector/setup.py
@@ -1,13 +1,11 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['march_data_collector'],
-    package_dir={'': 'src'},
     scripts=['scripts/march_data_collector'],
 )
 

--- a/march_description/CMakeLists.txt
+++ b/march_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_description)
 
 find_package(catkin REQUIRED COMPONENTS xacro)

--- a/march_description/package.xml
+++ b/march_description/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
     <name>march_description</name>
     <version>0.0.0</version>
     <description>The exoskeleton 3D model</description>

--- a/march_gain_scheduling/CMakeLists.txt
+++ b/march_gain_scheduling/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_gain_scheduling)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/march_gain_scheduling/CMakeLists.txt
+++ b/march_gain_scheduling/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(march_gain_scheduling)
 
 find_package(catkin REQUIRED COMPONENTS
-    dynamic_reconfigure
     march_shared_resources
-    rospy
     std_msgs
 )
 
@@ -13,18 +11,16 @@ catkin_python_setup()
 catkin_package(
     CATKIN_DEPENDS
     march_shared_resources
-    rospy
     std_msgs
 )
-
-install(DIRECTORY config launch
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-    )
-
-if(CATKIN_ENABLE_TESTING)
-    catkin_add_nosetests(test/one_step_linear_interpolation_test.py)
-endif()
 
 catkin_install_python(PROGRAMS scripts/${PROJECT_NAME}_node
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+install(DIRECTORY config launch
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+if(CATKIN_ENABLE_TESTING)
+    catkin_add_nosetests(test/one_step_linear_interpolation_test.py)
+endif()

--- a/march_gain_scheduling/package.xml
+++ b/march_gain_scheduling/package.xml
@@ -11,10 +11,11 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>python3-setuptools</buildtool_depend>
 
-  <depend>rospy</depend>
-  <depend>std_msgs</depend>
-  <depend>dynamic_reconfigure</depend>
   <depend>march_shared_resources</depend>
+  <depend>std_msgs</depend>
+
+  <exec_depend>dynamic_reconfigure</exec_depend>
+  <exec_depend>rospy</exec_depend>
 
   <test_depend>rosunit</test_depend>
 </package>

--- a/march_gain_scheduling/package.xml
+++ b/march_gain_scheduling/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_gain_scheduling</name>
   <version>0.0.0</version>
   <description>A feature package that implements gain scheduling control.</description>

--- a/march_gain_scheduling/package.xml
+++ b/march_gain_scheduling/package.xml
@@ -9,6 +9,7 @@
   <license>TODO</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python3-setuptools</buildtool_depend>
 
   <depend>rospy</depend>
   <depend>std_msgs</depend>

--- a/march_gain_scheduling/setup.py
+++ b/march_gain_scheduling/setup.py
@@ -1,13 +1,11 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 
-# fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['march_gain_scheduling'],
-    package_dir={'': 'src'},
+    scripts=['scripts/march_gain_scheduling_node'],
 )
 
 setup(**setup_args)

--- a/march_gain_scheduling/setup.py
+++ b/march_gain_scheduling/setup.py
@@ -1,10 +1,10 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-from setuptools import setup
-
 from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import setup
 
 setup_args = generate_distutils_setup(
     packages=['march_gain_scheduling'],
+    package_dir={'': 'src'},
     scripts=['scripts/march_gain_scheduling_node'],
 )
 

--- a/march_gait_scheduler/CMakeLists.txt
+++ b/march_gait_scheduler/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_gait_scheduler)
 
 add_compile_options(-std=c++14 -Wall -Wextra -Werror)

--- a/march_gait_scheduler/package.xml
+++ b/march_gait_scheduler/package.xml
@@ -8,14 +8,14 @@
 
     <buildtool_depend>catkin</buildtool_depend>
 
-    <depend>roscpp</depend>
-    <depend>march_shared_resources</depend>
     <depend>actionlib</depend>
     <depend>actionlib_msgs</depend>
     <depend>control_msgs</depend>
     <depend>dynamic_reconfigure</depend>
+    <depend>march_shared_resources</depend>
+    <depend>roscpp</depend>
     <depend>trajectory_msgs</depend>
 
-    <test_depend>rostest</test_depend>
     <test_depend>code_coverage</test_depend>
+    <test_depend>rostest</test_depend>
 </package>

--- a/march_gait_scheduler/package.xml
+++ b/march_gait_scheduler/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
     <name>march_gait_scheduler</name>
     <version>0.0.0</version>
     <description>Schedules and sends gaits to the controller</description>

--- a/march_gait_selection/CMakeLists.txt
+++ b/march_gait_selection/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_gait_selection)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/march_gait_selection/CMakeLists.txt
+++ b/march_gait_selection/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.0.2)
 project(march_gait_selection)
 
 find_package(catkin REQUIRED COMPONENTS
-    march_description
-    march_moveit
-    march_shared_classes
     march_shared_resources
     std_msgs
 )
@@ -12,9 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_python_setup()
 
 catkin_package(CATKIN_DEPENDS
-    march_description
-    march_moveit
-    march_shared_classes
     march_shared_resources
     std_msgs
 )
@@ -22,10 +16,9 @@ catkin_package(CATKIN_DEPENDS
 catkin_install_python(PROGRAMS scripts/${PROJECT_NAME}_node
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-
 install(DIRECTORY launch
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-    )
+)
 
 if (CATKIN_ENABLE_TESTING)
     find_package(rostest REQUIRED)

--- a/march_gait_selection/package.xml
+++ b/march_gait_selection/package.xml
@@ -8,6 +8,7 @@
   <license>TODO</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python3-setuptools</buildtool_depend>
 
   <depend>march_description</depend>
   <depend>march_moveit</depend>

--- a/march_gait_selection/package.xml
+++ b/march_gait_selection/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_gait_selection</name>
   <version>0.0.0</version>
   <description>Obtains the right gait file based on the gait name.</description>

--- a/march_gait_selection/package.xml
+++ b/march_gait_selection/package.xml
@@ -10,12 +10,11 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>python3-setuptools</buildtool_depend>
 
-  <depend>march_description</depend>
-  <depend>march_moveit</depend>
-  <depend>march_shared_classes</depend>
   <depend>march_shared_resources</depend>
   <depend>std_msgs</depend>
 
+  <exec_depend>march_description</exec_depend>
+  <exec_depend>march_shared_classes</exec_depend>
   <exec_depend>moveit_commander</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>urdfdom_py</exec_depend>

--- a/march_gait_selection/package.xml
+++ b/march_gait_selection/package.xml
@@ -15,6 +15,7 @@
   <depend>std_msgs</depend>
 
   <exec_depend>march_description</exec_depend>
+  <exec_depend>march_moveit</exec_depend>
   <exec_depend>march_shared_classes</exec_depend>
   <exec_depend>moveit_commander</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/march_gait_selection/setup.py
+++ b/march_gait_selection/setup.py
@@ -1,10 +1,10 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-from setuptools import setup
-
 from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import setup
 
 setup_args = generate_distutils_setup(
     packages=['march_gait_selection', 'march_gait_selection.dynamic_gaits'],
+    package_dir={'': 'src'},
     scripts=['scripts/march_gait_selection_node'],
 )
 

--- a/march_gait_selection/setup.py
+++ b/march_gait_selection/setup.py
@@ -1,13 +1,11 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 
-# fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['march_gait_selection', 'march_gait_selection.dynamic_gaits'],
-    package_dir={'': 'src'},
+    scripts=['scripts/march_gait_selection_node'],
 )
 
 setup(**setup_args)

--- a/march_launch/CMakeLists.txt
+++ b/march_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_launch)
 
 find_package(catkin REQUIRED)

--- a/march_launch/package.xml
+++ b/march_launch/package.xml
@@ -10,13 +10,16 @@
 
     <buildtool_depend>catkin</buildtool_depend>
 
+    <exec_depend>march_data_collector</exec_depend>
     <exec_depend>march_description</exec_depend>
-    <exec_depend>march_gait_scheduler</exec_depend>
     <exec_depend>march_gain_scheduling</exec_depend>
+    <exec_depend>march_gait_scheduler</exec_depend>
     <exec_depend>march_gait_selection</exec_depend>
+    <exec_depend>march_moveit</exec_depend>
     <exec_depend>march_safety</exec_depend>
     <exec_depend>march_state_machine</exec_depend>
-    <exec_depend>xacro</exec_depend>
     <exec_depend>rosserial_python</exec_depend>
     <exec_depend>rviz</exec_depend>
+    <exec_depend>sound_play</exec_depend>
+    <exec_depend>xacro</exec_depend>
 </package>

--- a/march_launch/package.xml
+++ b/march_launch/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
     <name>march_launch</name>
     <version>0.0.0</version>
     <description>Launches the related march packages</description>

--- a/march_moveit/CMakeLists.txt
+++ b/march_moveit/CMakeLists.txt
@@ -1,13 +1,9 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(march_moveit)
 
-find_package(catkin REQUIRED COMPONENTS
-    march_description
-    )
+find_package(catkin REQUIRED)
 
-catkin_package(CATKIN_DEPENDS
-    march_description
-    )
+catkin_package()
 
 install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   PATTERN "setup_assistant.launch" EXCLUDE)

--- a/march_moveit/CMakeLists.txt
+++ b/march_moveit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_moveit)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/march_moveit/package.xml
+++ b/march_moveit/package.xml
@@ -16,18 +16,22 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>march_description</exec_depend>
   <exec_depend>moveit_fake_controller_manager</exec_depend>
   <exec_depend>moveit_kinematics</exec_depend>
   <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_benchmarks</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_setup_assistant</exec_depend>
-  <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->
-  <build_depend>march_description</build_depend>
-  <exec_depend>march_description</exec_depend>
 </package>

--- a/march_moveit/package.xml
+++ b/march_moveit/package.xml
@@ -16,20 +16,18 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>moveit_fake_controller_manager</run_depend>
-  <run_depend>moveit_kinematics</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>moveit_setup_assistant</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>xacro</run_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_kinematics</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>moveit_setup_assistant</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
-  <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
+  <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->
   <build_depend>march_description</build_depend>
-  <run_depend>march_description</run_depend>
-
-
+  <exec_depend>march_description</exec_depend>
 </package>

--- a/march_moveit/package.xml
+++ b/march_moveit/package.xml
@@ -1,5 +1,6 @@
-<package>
-
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_moveit</name>
   <version>0.3.0</version>
   <description>

--- a/march_safety/CMakeLists.txt
+++ b/march_safety/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_safety)
 
 add_compile_options(-std=c++14 -Wall -Wextra -Werror)

--- a/march_safety/package.xml
+++ b/march_safety/package.xml
@@ -11,13 +11,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>roscpp</depend>
   <depend>march_shared_resources</depend>
+  <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>sound_play</depend>
   <depend>std_msgs</depend>
   <depend>urdf</depend>
-  <depend>sound_play</depend>
 
-  <test_depend>rostest</test_depend>
   <test_depend>code_coverage</test_depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/march_safety/package.xml
+++ b/march_safety/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_safety</name>
   <version>0.0.0</version>
   <description>

--- a/march_shared_classes/CMakeLists.txt
+++ b/march_shared_classes/CMakeLists.txt
@@ -1,12 +1,10 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(march_shared_classes)
 
-find_package(catkin REQUIRED COMPONENTS
-    march_shared_resources
-)
+find_package(catkin REQUIRED COMPONENTS march_shared_resources)
 
 catkin_python_setup()
-catkin_package()
+catkin_package(CATKIN_DEPENDS march_shared_resources)
 
 if(CATKIN_ENABLE_TESTING)
     catkin_add_nosetests(test/run_tests.py)

--- a/march_shared_classes/CMakeLists.txt
+++ b/march_shared_classes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_shared_classes)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/march_shared_classes/package.xml
+++ b/march_shared_classes/package.xml
@@ -7,6 +7,7 @@
   <license>TODO</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python3-setuptools</buildtool_depend>
 
   <depend>march_shared_resources</depend>
 

--- a/march_shared_classes/package.xml
+++ b/march_shared_classes/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_shared_classes</name>
   <version>0.0.0</version>
   <description>classes for the march packages</description>

--- a/march_shared_classes/package.xml
+++ b/march_shared_classes/package.xml
@@ -11,7 +11,7 @@
 
   <depend>march_shared_resources</depend>
 
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>python-scipy</exec_depend>
   <exec_depend>march_description</exec_depend>
+  <exec_depend>python-scipy</exec_depend>
+  <exec_depend>rospy</exec_depend>
 </package>

--- a/march_shared_classes/setup.py
+++ b/march_shared_classes/setup.py
@@ -1,10 +1,10 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-from setuptools import setup
-
 from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import setup
 
 setup_args = generate_distutils_setup(
     packages=['march_shared_classes', 'march_shared_classes.gait', 'march_shared_classes.exceptions'],
+    package_dir={'': 'src'},
 )
 
 setup(**setup_args)

--- a/march_shared_classes/setup.py
+++ b/march_shared_classes/setup.py
@@ -1,12 +1,10 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 
-# fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['march_shared_classes', 'march_shared_classes.gait', 'march_shared_classes.exceptions'],
-    package_dir={'': 'src'},
 )
 
 setup(**setup_args)

--- a/march_shared_resources/CMakeLists.txt
+++ b/march_shared_resources/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_shared_resources)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/march_shared_resources/CMakeLists.txt
+++ b/march_shared_resources/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED COMPONENTS
     actionlib_msgs
     control_msgs
     message_generation
-    message_runtime
     std_msgs
     trajectory_msgs
 )
@@ -56,9 +55,7 @@ catkin_package(
     CATKIN_DEPENDS
     actionlib_msgs
     control_msgs
-    message_generation
     message_runtime
     std_msgs
     trajectory_msgs
 )
-

--- a/march_shared_resources/package.xml
+++ b/march_shared_resources/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_shared_resources</name>
   <version>0.0.0</version>
   <description>custom messages for the march packages</description>

--- a/march_shared_resources/package.xml
+++ b/march_shared_resources/package.xml
@@ -9,17 +9,14 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>actionlib_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>message_runtime</build_depend>
   <build_depend>control_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
 
   <build_export_depend>actionlib_msgs</build_export_depend>
-  <build_export_depend>message_generation</build_export_depend>
-  <build_export_depend>message_runtime</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>control_msgs</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>trajectory_msgs</build_export_depend>
 
   <exec_depend>message_runtime</exec_depend>

--- a/march_state_machine/CMakeLists.txt
+++ b/march_state_machine/CMakeLists.txt
@@ -14,14 +14,14 @@ catkin_package(CATKIN_DEPENDS
     controller_manager_msgs
     march_shared_resources
     std_msgs
-)
-
-install(DIRECTORY launch sounds
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+    std_srvs
 )
 
 catkin_install_python(PROGRAMS scripts/${PROJECT_NAME}
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+install(DIRECTORY launch sounds
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
 ## Add folders to be run by python nosetests

--- a/march_state_machine/CMakeLists.txt
+++ b/march_state_machine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(march_state_machine)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/march_state_machine/package.xml
+++ b/march_state_machine/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>march_state_machine</name>
   <version>0.0.0</version>
   <description>The state machine of the March IV exoskeleton</description>

--- a/march_state_machine/package.xml
+++ b/march_state_machine/package.xml
@@ -10,17 +10,17 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>python3-setuptools</buildtool_depend>
 
-  <depend>std_srvs</depend>
-  <depend>std_msgs</depend>
   <depend>controller_manager_msgs</depend>
   <depend>march_shared_resources</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
 
   <build_export_depend>smach_viewer</build_export_depend>
 
-  <exec_depend>roslib</exec_depend>
-  <exec_depend>rospy</exec_depend>
   <exec_depend>executive_smach</exec_depend>
   <exec_depend>python-psutil</exec_depend>
+  <exec_depend>roslib</exec_depend>
+  <exec_depend>rospy</exec_depend>
   <exec_depend>smach_viewer</exec_depend>
   <exec_depend>sound_play</exec_depend>
 

--- a/march_state_machine/package.xml
+++ b/march_state_machine/package.xml
@@ -8,6 +8,7 @@
   <license>TODO</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>python3-setuptools</buildtool_depend>
 
   <depend>std_srvs</depend>
   <depend>std_msgs</depend>

--- a/march_state_machine/setup.py
+++ b/march_state_machine/setup.py
@@ -1,13 +1,13 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-from setuptools import setup
-
 from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import setup
 
 setup_args = generate_distutils_setup(
     packages=['march_state_machine',
               'march_state_machine.gaits',
               'march_state_machine.states',
               'march_state_machine.state_machines'],
+    package_dir={'': 'src'},
     scripts=['scripts/march_state_machine'],
 )
 

--- a/march_state_machine/setup.py
+++ b/march_state_machine/setup.py
@@ -1,15 +1,13 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
-from distutils.core import setup
+from setuptools import setup
 
 from catkin_pkg.python_setup import generate_distutils_setup
 
-# fetch values from package.xml
 setup_args = generate_distutils_setup(
     packages=['march_state_machine',
               'march_state_machine.gaits',
               'march_state_machine.states',
               'march_state_machine.state_machines'],
-    package_dir={'': 'src'},
     scripts=['scripts/march_state_machine'],
 )
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
I was making changes to support ROS Noetic, but I discovered that a lot of [the changes](https://wiki.ros.org/noetic/Migration) can already be incorporated into ROS Melodic, except from Python 3.

## Changes
* Update CMake version
* Update `setup.py` files to use `setuptools`
* Update all `package.xml` to use version 3
* Fix all dependencies by using `exec_depend` for Python packages and adding used packages

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
