### PR TITLE
Efficient implemention of setpoint interpolation

### DIFF
--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -14,6 +14,8 @@ class JointTrajectory(object):
         self.limits = limits
         self._setpoints = setpoints
         self._duration = duration
+        self.interpolated_position = None
+        self.interpolated_velocity = None
         self.interpolate_setpoints()
 
     @classmethod
@@ -102,7 +104,9 @@ class JointTrajectory(object):
 
     def interpolate_setpoints(self):
         if len(self.setpoints) == 1:
-            return [lambda time: self.setpoints[0].position, lambda time: self.setpoints[0].velocity]
+            self.interpolated_position = lambda time: self.setpoints[0].position
+            self.interpolated_velocity = lambda time: self.setpoints[0].velocity
+            return
 
         time, position, velocity = self.get_setpoints_unzipped()
         yi = []
@@ -112,7 +116,7 @@ class JointTrajectory(object):
         # We do a cubic spline here, just like the ros joint_trajectory_action_controller,
         # see https://wiki.ros.org/robot_mechanism_controllers/JointTrajectoryActionController
         self.interpolated_position = BPoly.from_derivatives(time, yi)
-        self.interpolated_velocity = self.interpolated_position .derivative()
+        self.interpolated_velocity = self.interpolated_position.derivative()
 
     def get_interpolated_setpoint(self, time):
         if time < 0:

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -46,9 +46,15 @@ class JointTrajectory(object):
     def duration(self):
         return self._duration
 
-    @duration.setter
-    def duration(self, duration):
-        self._duration = duration
+    def set_duration(self, new_duration, rescale=True):
+        for setpoint in reversed(self.setpoints):
+            if rescale:
+                setpoint.time = setpoint.time * new_duration / self.duration
+            else:
+                if setpoint.time > new_duration:
+                    self.setpoints.remove(setpoint)
+
+        self._duration = new_duration
         self.interpolate_setpoints()
 
     @property

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -206,14 +206,7 @@ class Subgait(object):
         new_duration = round(new_duration, Setpoint.digits)
 
         for joint in self.joints:
-            for setpoint in reversed(joint.setpoints):
-                if rescale:
-                    setpoint.time = setpoint.time * new_duration / self.duration
-                else:
-                    if setpoint.time > new_duration:
-                        joint.setpoints.remove(setpoint)
-
-            joint.duration = new_duration
+            joint.set_duration(new_duration, rescale)
         self.duration = new_duration
 
     def create_interpolated_setpoints(self, timestamps):

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -57,51 +57,22 @@ class JointTrajectoryTest(unittest.TestCase):
         self.assertFalse(joint_trajectory._validate_boundary_points())
 
     # interpolate_setpoints tests
-    def test_interpolation_time_points(self):
-        interpolated_list = self.joint_trajectory.interpolate_setpoints()
-        time_points = np.linspace(0, self.duration, len(interpolated_list[0]))
-        self.assertTrue((interpolated_list[0] == time_points).all())
+    def test_interpolation_start_point(self):
+        interpolated_setpoint = self.joint_trajectory.get_interpolated_setpoint(0)
+        self.assertEqual(interpolated_setpoint, self.setpoints[0])
 
-    def test_interpolation_start_point_position(self):
-        interpolated_list = self.joint_trajectory.interpolate_setpoints()
-        self.assertEqual(interpolated_list[1][0], self.setpoints[0].position)
-
-    def test_interpolation_start_point_velocity(self):
-        interpolated_list = self.joint_trajectory.interpolate_setpoints()
-        self.assertTrue(abs(interpolated_list[2][0] - self.setpoints[0].velocity) <= 0.1,
-                        msg='Interpolated start velocity {inter_v} was too far from actual start velocity '
-                            '{actual_v}'.format(inter_v=interpolated_list[2][0], actual_v=self.setpoints[0].velocity))
-
-    def test_interpolation_end_point_position(self):
-        interpolated_list = self.joint_trajectory.interpolate_setpoints()
-        self.assertEqual(interpolated_list[1][-1], self.setpoints[-1].position)
-
-    def test_interpolation_end_point_velocity(self):
-        interpolated_list = self.joint_trajectory.interpolate_setpoints()
-        self.assertTrue(abs(interpolated_list[2][-1] - self.setpoints[-1].velocity) <= 0.1,
-                        msg='Interpolated end velocity {inter_v} was too far from actual end velocity '
-                            '{actual_v}'.format(inter_v=interpolated_list[2][-1], actual_v=self.setpoints[-1].velocity))
+    def test_interpolation_end_point(self):
+        interpolated_setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration)
+        self.assertEqual(interpolated_setpoint, self.setpoints[-1])
 
     def test_interpolation_mid_point_position(self):
-        interpolated_list = self.joint_trajectory.interpolate_setpoints()
-        mid_index = len(interpolated_list[1]) / 2
-        inter_position = (interpolated_list[1][mid_index] + interpolated_list[1][mid_index - 1]) / 2
-        self.assertTrue(abs(inter_position - self.setpoints[1].position) <= 0.001,
-                        msg='Interpolated midpoint position {inter_x} was too far from actual midpoint position '
-                            '{actual_x}'.format(inter_x=inter_position, actual_x=self.setpoints[1].position))
-
-    def test_interpolation_mid_point_velocity(self):
-        interpolated_list = self.joint_trajectory.interpolate_setpoints()
-        mid_index = len(interpolated_list[1]) / 2
-        self.assertTrue(abs(interpolated_list[2][mid_index] - self.setpoints[1].velocity) <= 0.1,
-                        msg='Interpolated midpoint velocity {inter_v} was too far from actual midpoint velocity '
-                            '{actual_v}'.format(inter_v=interpolated_list[2][mid_index],
-                                                actual_v=self.setpoints[1].velocity))
+        interpolated_setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration/2)
+        self.assertEqual(interpolated_setpoint, self.setpoints[1])
 
     # get_interpolated_setpoint tests
     def test_get_interpolated_setpoints_invalid_time(self):
         setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration + 1)
-        self.assertEqual(setpoint, Setpoint(0, 0, 0))
+        self.assertEqual(setpoint, Setpoint(self.duration + 1, self.setpoints[-1].position, 0))
 
     def test_get_interpolated_setpoints_on_setpoint(self):
         setpoint = self.joint_trajectory.get_interpolated_setpoint(self.times[1])

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -67,9 +67,13 @@ class JointTrajectoryTest(unittest.TestCase):
         interpolated_setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration / 2)
         self.assertEqual(interpolated_setpoint, self.setpoints[1])
 
-    def test_get_interpolated_setpoints_invalid_time(self):
+    def test_get_interpolated_setpoints_invalid_time_too_high(self):
         setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration + 1)
         self.assertEqual(setpoint, Setpoint(self.duration + 1, self.setpoints[-1].position, 0))
+
+    def test_get_interpolated_setpoints_invalid_time_too_low(self):
+        setpoint = self.joint_trajectory.get_interpolated_setpoint(-1)
+        self.assertEqual(setpoint, Setpoint(-1, self.setpoints[0].position, 0))
 
     def test_get_interpolated_setpoints_home_subgait(self):
         self.joint_trajectory.setpoints = [Setpoint(3, 1, 1)]

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -67,15 +67,11 @@ class JointTrajectoryTest(unittest.TestCase):
         interpolated_setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration / 2)
         self.assertEqual(interpolated_setpoint, self.setpoints[1])
 
-    # get_interpolated_setpoint tests
     def test_get_interpolated_setpoints_invalid_time(self):
         setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration + 1)
         self.assertEqual(setpoint, Setpoint(self.duration + 1, self.setpoints[-1].position, 0))
 
-    def test_get_interpolated_setpoints_on_setpoint(self):
-        setpoint = self.joint_trajectory.get_interpolated_setpoint(self.times[1])
-        self.assertEqual(setpoint, self.setpoints[1])
-
-    def test_get_interpolated_setpoints(self):
-        setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration / 3.0)
-        self.assertIsInstance(setpoint, Setpoint)
+    def test_get_interpolated_setpoints_home_subgait(self):
+        self.joint_trajectory.setpoints = [Setpoint(3, 1, 1)]
+        setpoint = self.joint_trajectory.get_interpolated_setpoint(1)
+        self.assertEqual(setpoint, Setpoint(1, 1, 1))

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -1,7 +1,5 @@
 import unittest
 
-import numpy as np
-
 from march_shared_classes.gait.joint_trajectory import JointTrajectory
 from march_shared_classes.gait.limits import Limits
 from march_shared_classes.gait.setpoint import Setpoint
@@ -66,7 +64,7 @@ class JointTrajectoryTest(unittest.TestCase):
         self.assertEqual(interpolated_setpoint, self.setpoints[-1])
 
     def test_interpolation_mid_point_position(self):
-        interpolated_setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration/2)
+        interpolated_setpoint = self.joint_trajectory.get_interpolated_setpoint(self.duration / 2)
         self.assertEqual(interpolated_setpoint, self.setpoints[1])
 
     # get_interpolated_setpoint tests


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-478
Merge together with https://github.com/project-march/gait-generation/pull/99
The built fails because of this dependency :s

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

For some reason, every time an interpolated setpoint was requested the following happened: 1) the entire gait would be interpolated 2) the interpolation would be sampled every 0.01 seconds 3) the two samples closest to the requested time would be found 4) these would be interpolated linearly to get the result. My eyes starting tearing by just looking at it.

In this PR, the interpolation is done only once at startup. The interpolation is saved as a function rather than a list of samples. Life is better now.

Unfortunately, startup is not faster as I once announced. Because the interpolation was never done at startup, only every time any interpolated point was requested. Since the interpolation is now done at startup, it is actually a bit slower instead. Loading the gait selection takes on average:
Before: 4.29 seconds
After: 4.91 seconds

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

* Do interpolation during initialization of a JointTrajectory object
* Save interpolation as two functions instead of a list of interpolated points

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
