### PR TITLE
Feature: add gait version service

### DIFF
--- a/march_gait_selection/src/march_gait_selection/dynamic_gaits/transition_subgait.py
+++ b/march_gait_selection/src/march_gait_selection/dynamic_gaits/transition_subgait.py
@@ -38,7 +38,7 @@ class TransitionSubgait(Subgait):
         old_subgait, new_subgait = cls._get_copy_of_subgaits(gait_selection, old_gait_name, new_gait_name,
                                                              new_subgait_name, old_subgait_name)
 
-        transition_joints = cls._transition_joints(gait_selection.robot, old_subgait, new_subgait)
+        transition_joints = cls._transition_joints(gait_selection.get_robot(), old_subgait, new_subgait)
         transition_duration = new_subgait.duration
 
         transition_subgait = cls(transition_joints, transition_duration)

--- a/march_gait_selection/src/march_gait_selection/dynamic_gaits/transition_subgait.py
+++ b/march_gait_selection/src/march_gait_selection/dynamic_gaits/transition_subgait.py
@@ -65,12 +65,8 @@ class TransitionSubgait(Subgait):
             raise GaitError(msg='{gn} not found in parsed gait names from gait selection'
                             .format(gn=new_gait_name))
 
-        if old_gait.to_subgaits_names != new_gait.to_subgaits_names:
-            raise GaitError(msg='To_subgait list do not match between gait: {cg} and gait: {ng}'
-                            .format(cg=old_gait_name, ng=new_gait_name))
-
-        if old_gait.from_subgaits_names != new_gait.from_subgaits_names:
-            raise GaitError(msg='From_subgait list do not match between gait: {cg} and gait: {ng}'
+        if old_gait.graph != new_gait.graph:
+            raise GaitError(msg='Subgait graphs do not match between gait: {cg} and gait: {ng}'
                             .format(cg=old_gait_name, ng=new_gait_name))
 
         old_subgait_name = new_subgait_name if old_subgait_name is None else old_subgait_name
@@ -139,13 +135,16 @@ class TransitionSubgait(Subgait):
     @staticmethod
     def _validate_transition_gait(old_subgait, transition_subgait, new_subgait):
         """Validate the transition point by creating a gait object which checks the trajectories."""
-        subgaits = [old_subgait, transition_subgait, new_subgait]
-        from_subgaits = ['start', old_subgait.subgait_name, transition_subgait.subgait_name,
-                         new_subgait.subgait_name]
-        to_subgaits = [old_subgait.subgait_name, transition_subgait.subgait_name, new_subgait.subgait_name, 'end']
+        subgaits = {old_subgait.subgait_name: old_subgait,
+                    transition_subgait.subgait_name: transition_subgait,
+                    new_subgait.subgait_name: new_subgait}
+        graph = {'start': old_subgait.subgait_name,
+                 old_subgait.subgait_name: transition_subgait.subgait_name,
+                 transition_subgait.subgait_name: new_subgait.subgait_name,
+                 new_subgait.subgait_name: 'end'}
 
         try:
-            Gait('transition', subgaits, from_subgaits, to_subgaits)
+            Gait('transition', subgaits, graph)
         except Exception as error:
             TransitionError('Error when creating transition: {er}'.format(er=error))
 

--- a/march_gait_selection/src/march_gait_selection/gait_selection.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection.py
@@ -36,6 +36,9 @@ class GaitSelection(object):
         except rospkg.common.ResourceNotFound:
             raise PackageNotFoundError(package)
 
+    def get_robot(self):
+        return self._robot
+
     def get_gait_version_map(self):
         """Returns the mapping from gaits and subgaits to versions."""
         return self._gait_version_map
@@ -144,4 +147,4 @@ class GaitSelection(object):
 
     def __getitem__(self, name):
         """Returns a gait from the loaded gaits."""
-        return self._loaded_gaits[name]
+        return self._loaded_gaits.get(name)

--- a/march_gait_selection/src/march_gait_selection/gait_selection.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection.py
@@ -15,139 +15,127 @@ class GaitSelection(object):
     """Base class for the gait selection module."""
 
     def __init__(self, package, directory):
-        self.loaded_gaits = None
-        self.gait_directory = None
-        self.joint_names = list()
-        self.robot = None
-
         package_path = self.get_ros_package_path(package)
-        self.default_yaml = os.path.join(package_path, directory, 'default.yaml')
+        self._gait_directory = os.path.join(package_path, directory)
+        self._default_yaml = os.path.join(self._gait_directory, 'default.yaml')
 
-        if not os.path.isfile(self.default_yaml):
-            raise FileNotFoundError(file_path=self.default_yaml)
+        if not os.path.isfile(self._default_yaml):
+            raise FileNotFoundError(file_path=self._default_yaml)
 
-        with open(self.default_yaml, 'r') as default_yaml_file:
-            default_config = yaml.load(default_yaml_file, Loader=yaml.SafeLoader)
+        self._robot = urdf.Robot.from_parameter_server('/robot_description')
+        self._balance_gait = BalanceGait()
 
-        self.gait_directory = os.path.join(package_path, directory)
-        self._gait_version_map = default_config['gaits']
-
-        self.robot = urdf.Robot.from_parameter_server('/robot_description')
-        self.joint_names = [joint.name for joint in self.robot.joints if joint.type != 'fixed']
-
-        rospy.loginfo('GaitSelection initialized with package: {pk} of directory {dr}'.format(pk=package, dr=directory))
-        rospy.logdebug('GaitSelection initialized with gait_version_map: {vm}'.format(vm=str(self.gait_version_map)))
-
-        self.balance_gait = BalanceGait()
-        self.gait_version_map = self._gait_version_map
+        self._gait_version_map = self._load_version_map()
+        self._loaded_gaits = self._load_gaits()
 
     @staticmethod
     def get_ros_package_path(package):
-        """Get the path of where the given (ros) package is located."""
+        """Returns the path of where the given (ros) package is located."""
         try:
             return rospkg.RosPack().get_path(package)
         except rospkg.common.ResourceNotFound:
             raise PackageNotFoundError(package)
 
-    @property
-    def gait_version_map(self):
-        """Get the version map of the gait selection module as property."""
+    def get_gait_version_map(self):
+        """Returns the mapping from gaits and subgaits to versions."""
         return self._gait_version_map
 
-    @gait_version_map.setter
-    def gait_version_map(self, new_version_map):
-        """Set new version map and reload the gaits from the directory."""
-        if not type(new_version_map) is dict:
-            raise TypeError('Gait version map should be of type; dictionary.')
+    def set_gait_versions(self, gait_name, subgait_names, versions):
+        """Sets the subgait versions of given gait.
 
-        if len(new_version_map) == 0:
-            raise GaitError(msg='Gait version map: {gm}, is empty'.format(gm=new_version_map))
-
-        if not self.validate_versions_in_directory(new_version_map):
-            raise GaitError(msg='Gait version map: {gm}, is not valid'.format(gm=new_version_map))
-
-        self._gait_version_map = new_version_map
-        self.load_gaits()
-
-    def load_gaits(self):
-        """Load the gaits in the specified gait directory."""
-        self.loaded_gaits = [self.balance_gait]
-
-        for gait in self._gait_version_map:
-            loaded_gait = Gait.from_file(gait, self.gait_directory, self.robot, self._gait_version_map)
-            self.loaded_gaits.append(loaded_gait)
-
-        self.balance_gait.default_walk = self['walk']
+        :param str gait_name: Name of the gait to change versions
+        :param list(str) subgait_names: List of subgait names of which to change versions
+        :param list(str) versions: Names of the new versions
+        """
+        pass
 
     def scan_directory(self):
-        """Scan the gait_directory recursively and create a dictionary of all subgait files.
+        """Scans the gait_directory recursively and create a dictionary of all subgait files.
 
         :returns:
             dictionary of the maps and files within the directory
         """
-        root_dir = self.gait_directory.rstrip(os.sep)
-
-        directory_dict = {}
-        for gait in os.listdir(root_dir):
-            gait_path = os.path.join(root_dir, gait)
+        gaits = {}
+        for gait in os.listdir(self._gait_directory):
+            gait_path = os.path.join(self._gait_directory, gait)
 
             if os.path.isdir(gait_path):
-                gait_dict = {'image': os.path.join(gait_path, gait + '.png'), 'subgaits': {}}
+                subgaits = {}
 
                 for subgait in os.listdir(gait_path):
                     subgait_path = os.path.join(gait_path, subgait)
 
                     if os.path.isdir(subgait_path):
-                        versions = []
-                        for version in os.listdir(os.path.join(subgait_path)):
-                            if version.endswith('.subgait'):
-                                versions.append(version.replace('.subgait', ''))
-
+                        versions = [v.replace('.subgait', '') for v in os.listdir(os.path.join(subgait_path)) if
+                                    v.endswith('.subgait')]
                         versions.sort()
-                        gait_dict['subgaits'][subgait] = versions
+                        subgaits[subgait] = versions
 
-                    directory_dict[gait] = gait_dict
-        return directory_dict
+                gaits[gait] = subgaits
+        return gaits
 
-    def validate_versions_in_directory(self, new_gait_version_map):
-        """Validate if the given version numbers in the version map exist in the selected directory."""
-        for gait_name in new_gait_version_map:
-            if not self.validate_gait_in_directory(gait_name):
+    def update_default_versions(self):
+        """Updates the default.yaml file with the current loaded gait versions."""
+        new_default_dict = {'gaits': self._gait_version_map}
+
+        try:
+            with open(self._default_yaml, 'w') as default_yaml_content:
+                yaml_content = yaml.dump(new_default_dict)
+                default_yaml_content.write(yaml_content)
+            return [True, 'New default values were written to: {pn}'.format(pn=self._default_yaml)]
+
+        except IOError:
+            return [False, 'Error occurred when writing to file path: {pn}'.format(pn=self._default_yaml)]
+
+    def _load_gaits(self):
+        """Loads the gaits in the specified gait directory.
+
+        :returns dict: A dictionary mapping gait name to gait instance
+        """
+        gaits = {self._balance_gait.gait_name: self._balance_gait}
+
+        for gait in self._gait_version_map:
+            gaits[gait] = Gait.from_file(gait, self._gait_directory, self._robot, self._gait_version_map)
+
+        self._balance_gait.default_walk = gaits['walk']
+        return gaits
+
+    def _load_version_map(self):
+        """Loads and verifies the version map from the default version map."""
+        with open(self._default_yaml, 'r') as default_yaml_file:
+            default_config = yaml.load(default_yaml_file, Loader=yaml.SafeLoader)
+
+        version_map = default_config['gaits']
+
+        if not isinstance(version_map, dict):
+            raise TypeError('Gait version map should be of type; dictionary')
+
+        if not self._validate_version_map(version_map):
+            raise GaitError(msg='Gait version map: {gm}, is not valid'.format(gm=version_map))
+
+        return version_map
+
+    def _validate_version_map(self, version_map):
+        """Validates if the current versions exist.
+
+        :param dict version_map: Version map to verify
+        :returns bool: True when all versions exist, False otherwise
+        """
+        for gait_name in version_map:
+            gait_path = os.path.join(self._gait_directory, gait_name)
+            if not os.path.isfile(os.path.join(gait_path, gait_name + '.gait')):
                 rospy.logwarn('gait {gn} does not exist'.format(gn=gait_name))
                 return False
 
-            for subgait_name in new_gait_version_map[gait_name]:
-                version = new_gait_version_map[gait_name][subgait_name]
-                subgait_path = os.path.join(self.gait_directory, gait_name, subgait_name, version + '.subgait')
+            for subgait_name in version_map[gait_name]:
+                version = version_map[gait_name][subgait_name]
+                subgait_path = os.path.join(gait_path, subgait_name, version + '.subgait')
 
                 if not os.path.isfile(subgait_path):
                     rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
                     return False
         return True
 
-    def validate_gait_in_directory(self, gait_name):
-        """Check if the .gait file exists in the given directory."""
-        gait_map = gait_name
-        gait_path = os.path.join(self.gait_directory, gait_map, gait_name + '.gait')
-
-        if not os.path.isfile(gait_path):
-            return False
-        else:
-            return True
-
-    def update_default_versions(self):
-        """Update the default.yaml file in the given directory."""
-        new_default_dict = {'gaits': self.gait_version_map}
-
-        try:
-            with open(self.default_yaml, 'w') as default_yaml_content:
-                yaml_content = yaml.dump(new_default_dict)
-                default_yaml_content.write(yaml_content)
-            return [True, 'New default values were written to: {pn}'.format(pn=self.default_yaml)]
-
-        except IOError:
-            return [False, 'Error occurred when writing to file path: {pn}'.format(pn=self.default_yaml)]
-
     def __getitem__(self, name):
-        """Get a gait from the loaded gaits."""
-        return next((gait for gait in self.loaded_gaits if gait.gait_name == name), None)
+        """Returns a gait from the loaded gaits."""
+        return self._loaded_gaits[name]

--- a/march_gait_selection/src/march_gait_selection/gait_selection_node.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection_node.py
@@ -1,7 +1,6 @@
 import rospy
 from std_srvs.srv import Trigger
 
-from march_shared_classes.exceptions.gait_exceptions import GaitError
 from march_shared_resources.srv import ContainsGait, ContainsGaitResponse, SetGaitVersion
 
 from .gait_selection import GaitSelection
@@ -19,10 +18,14 @@ def set_gait_versions(msg, gait_selection):
     :type gait_selection: GaitSelection
     :rtype march_shared_resources.srv.SetGaitVersionResponse
     """
+    if len(msg.subgaits) != len(msg.versions):
+        return [False, '`subgaits` and `versions` array are not of equal length']
+
+    version_map = dict(zip(msg.subgaits, msg.versions))
     try:
-        gait_selection.set_gait_versions(msg.gait, msg.subgaits, msg.versions)
+        gait_selection.set_gait_versions(msg.gait, version_map)
         return [True, '']
-    except GaitError as e:
+    except Exception as e:
         return [False, str(e)]
 
 

--- a/march_gait_selection/test/nosetests/test_gait_selection.py
+++ b/march_gait_selection/test/nosetests/test_gait_selection.py
@@ -20,7 +20,6 @@ class TestGaitSelection(unittest.TestCase):
 
     def setUp(self):
         self.gait_selection = deepcopy(self._gait_selection)
-        self.gait_version_map = deepcopy(self._gait_selection.gait_version_map)
 
     # __init__ tests
     def test_init_with_wrong_package(self):
@@ -33,8 +32,8 @@ class TestGaitSelection(unittest.TestCase):
 
     # load gaits tests
     def test_types_in_loaded_gaits(self):
-        for gait in self.gait_selection._loaded_gaits:
-            self.assertIsInstance(gait, (Gait, BalanceGait))
+        for gait in self.gait_selection._loaded_gaits.values():
+            self.assertTrue(isinstance(gait, Gait) or isinstance(gait, BalanceGait))
 
     # scan directory tests
     def test_scan_directory_top_level_content(self):
@@ -43,8 +42,7 @@ class TestGaitSelection(unittest.TestCase):
 
     def test_scan_directory_subgait_versions(self):
         directory = self.gait_selection.scan_directory()
-        walk_subgaits = directory['walk']['subgaits']
-        self.assertEqual(walk_subgaits['left_swing'], ['MV_walk_leftswing_v2'])
+        self.assertEqual(directory['walk']['left_swing'], ['MV_walk_leftswing_v2'])
 
     # get item tests
     def test_get_item_with_wrong_name(self):

--- a/march_gait_selection/test/nosetests/test_gait_selection.py
+++ b/march_gait_selection/test/nosetests/test_gait_selection.py
@@ -5,7 +5,6 @@ import unittest
 
 from march_gait_selection.dynamic_gaits.balance_gait import BalanceGait
 from march_gait_selection.gait_selection import GaitSelection
-from march_shared_classes.exceptions.gait_exceptions import GaitError
 from march_shared_classes.exceptions.general_exceptions import FileNotFoundError, PackageNotFoundError
 from march_shared_classes.gait.gait import Gait
 
@@ -32,34 +31,9 @@ class TestGaitSelection(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             GaitSelection(VALID_PACKAGE, 'wrong')
 
-    # gait version map setter tests
-    def test_set_gait_version_map_with_wrong_type(self):
-        with self.assertRaises(TypeError):
-            self.gait_selection.gait_version_map = 'wrong'
-
-    def test_set_gait_version_map_with_empty_version_map(self):
-        self.gait_version_map = {}
-        with self.assertRaises(GaitError):
-            self.gait_selection.gait_version_map = self.gait_version_map
-
-    def test_set_gait_version_map_with_non_existing_gait_name(self):
-        self.gait_version_map['wrong'] = self.gait_version_map['walk']
-        with self.assertRaises(GaitError):
-            self.gait_selection.gait_version_map = self.gait_version_map
-
-    def test_set_gait_version_map_with_non_existing_subgait_name(self):
-        self.gait_version_map['walk']['wrong'] = self.gait_version_map['walk']['right_open']
-        with self.assertRaises(GaitError):
-            self.gait_selection.gait_version_map = self.gait_version_map
-
-    def test_set_gait_version_map_with_wrong_subgait_version(self):
-        self.gait_version_map['walk']['right_open'] = 'wrong'
-        with self.assertRaises(GaitError):
-            self.gait_selection.gait_version_map = self.gait_version_map
-
     # load gaits tests
     def test_types_in_loaded_gaits(self):
-        for gait in self.gait_selection.loaded_gaits:
+        for gait in self.gait_selection._loaded_gaits:
             self.assertIsInstance(gait, (Gait, BalanceGait))
 
     # scan directory tests

--- a/march_shared_classes/src/march_shared_classes/gait/gait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/gait.py
@@ -10,17 +10,22 @@ from march_shared_classes.gait.subgait import Subgait
 class Gait(object):
     """base class for a generated gait."""
 
-    def __init__(self, gait_name, subgaits, from_subgaits_names, to_subgaits_names, *args):
-        self._validate_gait_file(gait_name, from_subgaits_names, to_subgaits_names)
-        self._validate_trajectory_transition(subgaits, from_subgaits_names, to_subgaits_names)
+    def __init__(self, gait_name, subgaits, graph):
+        """Initializes and verifies the gait.
+
+        :param str gait_name: Name of the gait
+        :param dict subgaits: Mapping of names to subgait instances
+        :param dict graph: Mapping of subgait names transitions
+        """
+        self._validate_gait_graph(gait_name, graph)
+        self._validate_trajectory_transition(subgaits, graph)
 
         self.gait_name = gait_name
         self.subgaits = subgaits
-        self.from_subgaits_names = from_subgaits_names
-        self.to_subgaits_names = to_subgaits_names
+        self.graph = graph
 
     @classmethod
-    def from_file(cls, gait_name, gait_directory, robot, gait_version_map, *args):
+    def from_file(cls, gait_name, gait_directory, robot, gait_version_map):
         """Extract the data from the .gait file.
 
         :param gait_name:
@@ -40,10 +45,10 @@ class Gait(object):
         with open(gait_path, 'r') as gait_file:
             gait_dictionary = yaml.load(gait_file, Loader=yaml.SafeLoader)
 
-        return cls.from_dict(robot, gait_dictionary, gait_directory, gait_version_map, *args)
+        return cls.from_dict(robot, gait_dictionary, gait_directory, gait_version_map)
 
     @classmethod
-    def from_dict(cls, robot, gait_dictionary, gait_directory, gait_version_map, *args):
+    def from_dict(cls, robot, gait_dictionary, gait_directory, gait_version_map):
         """Create a new gait object using the .gait and .subgait files.
 
         :param robot:
@@ -63,14 +68,17 @@ class Gait(object):
 
         from_subgaits_names = gait_content['from_subgait']
         to_subgaits_names = gait_content['to_subgait']
+        if len(from_subgaits_names) != len(to_subgaits_names):
+            raise NonValidGaitContent('to_subgait and from_subgait are not of equal length')
 
-        subgait_names = gait_content['from_subgait'] + gait_content['to_subgait']
-        subgait_names = filter(lambda name: name not in ('start', 'end'), subgait_names)
+        graph = dict(zip(from_subgaits_names, to_subgaits_names))
+        cls._validate_gait_graph(gait_name, graph)
 
-        subgaits = [cls.load_subgait(robot, gait_directory, gait_name, subgait_name, gait_version_map)
-                    for subgait_name in subgait_names]
+        subgait_names = set(from_subgaits_names + to_subgaits_names)
+        subgaits = dict([(name, cls.load_subgait(robot, gait_directory, gait_name, name, gait_version_map))
+                         for name in subgait_names if name not in ('start', 'end')])
 
-        return cls(gait_name, subgaits, from_subgaits_names, to_subgaits_names, *args)
+        return cls(gait_name, subgaits, graph)
 
     @staticmethod
     def load_subgait(robot, gait_directory, gait_name, subgait_name, gait_version_map):
@@ -79,9 +87,9 @@ class Gait(object):
         :returns
             if gait and subgait names are valid return populated Gait object
         """
-        if not gait_version_map.get(gait_name):
+        if gait_name not in gait_version_map:
             raise GaitNameNotFound(gait_name)
-        if not gait_version_map[gait_name].get(subgait_name):
+        if subgait_name not in gait_version_map[gait_name]:
             raise SubgaitNameNotFound(subgait_name)
 
         version = gait_version_map[gait_name][subgait_name]
@@ -92,46 +100,49 @@ class Gait(object):
         return Subgait.from_file(robot, subgait_path)
 
     @staticmethod
-    def _validate_gait_file(gait_name, from_subgait_names, to_subgait_names):
+    def _validate_gait_graph(gait_name, graph):
         """Validate if the data in the gait file is valid.
 
-        :param from_subgait_names:
-            the list of subgait names stated as from_subgaits in the .gait file
-        :param to_subgait_names:
-            the list of subgait names stated as to_subgaits in the .gait file
+        :param dict graph: Mapping of subgaits that transition to other subgaits
         """
-        if len(from_subgait_names) != len(to_subgait_names):
-            raise NonValidGaitContent(msg='Gait {gn} does not have equal amount of subgaits'.format(gn=gait_name))
-
-        if 'start' not in from_subgait_names or 'start' in to_subgait_names:
+        if 'start' not in graph.keys() or 'start' in graph.values():
             raise NonValidGaitContent(msg='Gait {gn} does not have valid starting subgaits'.format(gn=gait_name))
 
-        if 'end' not in to_subgait_names or 'end' in from_subgait_names:
+        if 'end' not in graph.values() or 'end' in graph.keys():
             raise NonValidGaitContent(msg='Gait {gn} does not have valid ending subgaits'.format(gn=gait_name))
 
     @staticmethod
-    def _validate_trajectory_transition(subgaits, from_subgait_names, to_subgait_names):
-        """Compare and validate the trajectory end and start points.
+    def _validate_trajectory_transition(subgaits, graph):
+        """Compares and validates the trajectory end and start points.
 
-        :param subgaits:
-            The list of subgait objects used in this gait
-        :param from_subgait_names:
-            the list of subgait names stated as from_subgaits in the .gait file
-        :param to_subgait_names:
-            the list of subgait names stated as to_subgaits in the .gait file
+        :param dict subgaits: Mapping of subgait names to subgait instances
+        :param dict graph: Mapping of subgaits transitions
         """
-        for from_subgait_name, to_subgait_name in zip(from_subgait_names, to_subgait_names):
+        for from_subgait_name, to_subgait_name in graph.items():
 
-            if not all(name not in ('start', 'end', None) for name in (from_subgait_name, to_subgait_name)):
-                continue  # a start or end point can not be compared to a subgait
+            if any(name in ('start', 'end', None) for name in (from_subgait_name, to_subgait_name)):
+                continue  # a start or end point cannot be compared to a subgait
 
-            from_subgait = next((subgait for subgait in subgaits if subgait.subgait_name == from_subgait_name), None)
-            to_subgait = next((subgait for subgait in subgaits if subgait.subgait_name == to_subgait_name), None)
+            from_subgait = subgaits[from_subgait_name]
+            to_subgait = subgaits[to_subgait_name]
 
             if not from_subgait.validate_subgait_transition(to_subgait):
                 raise NonValidGaitContent(msg='End setpoint of subgait {sn} to subgait {ns} does not match'
                                           .format(sn=from_subgait.subgait_name, ns=to_subgait.subgait_name))
 
+    def set_subgait_versions(self, robot, gait_directory, version_map):
+        """Updates the given subgait versions and verifies transitions.
+
+        :param str gait_directory: path to the gait directory
+        :param dict version_map: Mapping subgait names to versions
+        """
+        for subgait_name in version_map.keys():
+            if self.__getitem__(subgait_name) is None:
+                raise SubgaitNameNotFound(subgait_name,
+                                          'Subgait {0} does not exist for {1}'.format(subgait_name, self.gait_name))
+
+        pass
+
     def __getitem__(self, name):
-        """Get a subgait from the loaded subgaits."""
-        return next((subgait for subgait in self.subgaits if subgait.subgait_name == name), None)
+        """Returns a subgait from the loaded subgaits."""
+        return self.subgaits[name]

--- a/march_shared_classes/src/march_shared_classes/gait/gait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/gait.py
@@ -169,4 +169,4 @@ class Gait(object):
 
     def __getitem__(self, name):
         """Returns a subgait from the loaded subgaits."""
-        return self.subgaits[name]
+        return self.subgaits.get(name)

--- a/march_shared_classes/test/gait_test.py
+++ b/march_shared_classes/test/gait_test.py
@@ -27,6 +27,7 @@ class GaitTest(unittest.TestCase):
                              'left_swing', 'right_close']
         self.to_subgait = ['right_open', 'left_swing', 'right_swing', 'left_close', 'end', 'right_open', 'left_swing',
                            'right_close', 'end']
+        self.graph = zip(self.from_subgait, self.to_subgait)
 
     # Gait.from_file tests
     def test_from_file_valid_path(self):
@@ -36,42 +37,36 @@ class GaitTest(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             Gait.from_file(self.gait_name, self.resources_folder + '/gaits', self.robot, self.gait_version_map)
 
-    # __init__ (_validate_gait_file) tests
-    def test_init_invalid_gait_file_unequal_length(self):
-        from_subgait = ['start', 'right_open', 'left_swing', 'right_swing', 'left_close', 'start', 'right_open',
-                        'left_swing', 'right_close', 'left_close']
-        with self.assertRaises(NonValidGaitContent):
-            Gait(self.gait_name, self.gait.subgaits, from_subgait, self.to_subgait)
-
+    # __init__ (_validate_gait_graph) tests
     def test_init_invalid_gait_file_no_start(self):
-        from_subgait = ['right_open', 'right_open', 'left_swing', 'right_swing', 'left_close', 'start', 'right_open',
-                        'left_swing', 'right_close']
+        from_subgait = ['right_open', 'right_open', 'left_swing', 'right_swing', 'left_close',
+                        'left_close', 'right_open', 'left_swing', 'right_close']
         with self.assertRaises(NonValidGaitContent):
-            Gait(self.gait_name, self.gait.subgaits, from_subgait, self.to_subgait)
+            Gait(self.gait_name, self.gait.subgaits, zip(from_subgait, self.to_subgait))
 
     def test_init_invalid_gait_file_start_in_to_subgait(self):
-        to_subgait = ['start', 'left_swing', 'right_swing', 'left_close', 'end', 'right_open', 'left_swing',
-                      'right_close', 'end']
+        to_subgait = ['start', 'left_swing', 'right_swing', 'left_close', 'end',
+                      'right_open', 'left_swing', 'right_close', 'end']
         with self.assertRaises(NonValidGaitContent):
-            Gait(self.gait_name, self.gait.subgaits, self.from_subgait, to_subgait)
+            Gait(self.gait_name, self.gait.subgaits, zip(self.from_subgait, to_subgait))
 
     def test_init_invalid_gait_file_no_end(self):
-        to_subgait = ['right_open', 'left_swing', 'right_swing', 'left_close', 'end', 'right_open', 'left_swing',
-                      'right_close', 'left_close']
+        to_subgait = ['right_open', 'left_swing', 'right_swing', 'left_close', 'right_swing',
+                      'right_open', 'left_swing', 'right_close', 'left_close']
         with self.assertRaises(NonValidGaitContent):
-            Gait(self.gait_name, self.gait.subgaits, self.from_subgait, to_subgait)
+            Gait(self.gait_name, self.gait.subgaits, zip(self.from_subgait, to_subgait))
 
     def test_init_invalid_gait_file_end_in_from_subgait(self):
         from_subgait = ['start', 'right_open', 'left_swing', 'right_swing', 'left_close', 'start', 'right_open',
                         'left_swing', 'end']
         with self.assertRaises(NonValidGaitContent):
-            Gait(self.gait_name, self.gait.subgaits, from_subgait, self.to_subgait)
+            Gait(self.gait_name, self.gait.subgaits, zip(from_subgait, self.to_subgait))
 
     # __init__ (_validate_trajectory_transition) test
-    def test_init_invalid_joint_trjaectory_transition(self):
-        self.gait.subgaits[0].joints[0].setpoints[-1].position = 124
+    def test_init_invalid_joint_trajectory_transition(self):
+        self.gait.subgaits['left_swing'].joints[0].setpoints[-1].position = 124
         with self.assertRaises(NonValidGaitContent):
-            Gait(self.gait_name, self.gait.subgaits, self.from_subgait, self.to_subgait)
+            Gait(self.gait_name, self.gait.subgaits, self.graph)
 
     # load_subgait tests
     def test_load_existing_subgait(self):

--- a/march_shared_classes/test/gait_test.py
+++ b/march_shared_classes/test/gait_test.py
@@ -87,3 +87,36 @@ class GaitTest(unittest.TestCase):
 
         with self.assertRaises(FileNotFoundError):
             Gait.load_subgait(self.robot, self.resources_folder, self.gait_name, 'right_open', self.gait_version_map)
+
+    def test_set_no_subgait_versions(self):
+        self.gait.set_subgait_versions(self.robot, self.resources_folder, {})
+
+    def test_set_one_new_subgait_version(self):
+        subgait_name = 'left_close'
+        new_version = 'MIV_final'
+        self.gait.set_subgait_versions(self.robot, self.resources_folder, {subgait_name: new_version})
+        self.assertEqual(new_version, self.gait.subgaits[subgait_name].version)
+
+    def test_set_multiple_subgait_versions(self):
+        subgait_name1 = 'left_close'
+        subgait_name2 = 'left_swing'
+        new_version = 'MIV_final'
+        self.gait.set_subgait_versions(self.robot, self.resources_folder,
+                                       {subgait_name1: new_version, subgait_name2: new_version})
+        self.assertEqual(new_version, self.gait.subgaits[subgait_name1].version)
+        self.assertEqual(new_version, self.gait.subgaits[subgait_name2].version)
+
+    def test_set_version_non_existing_subgait(self):
+        with self.assertRaises(SubgaitNameNotFound):
+            self.gait.set_subgait_versions(self.robot, self.resources_folder, {'this_subgait_does_not_exist': '1'})
+
+    def test_set_non_existing_version_subgait(self):
+        with self.assertRaises(FileNotFoundError):
+            self.gait.set_subgait_versions(self.robot, self.resources_folder, {'left_swing': '1'})
+
+    def test_set_new_subgait_version_invalid_transition(self):
+        self.gait.subgaits['right_swing'].joints[0].setpoints[-1].position = 124
+        subgait_name = 'left_close'
+        new_version = 'MIV_final'
+        with self.assertRaises(NonValidGaitContent):
+            self.gait.set_subgait_versions(self.robot, self.resources_folder, {subgait_name: new_version})

--- a/march_shared_resources/CMakeLists.txt
+++ b/march_shared_resources/CMakeLists.txt
@@ -32,8 +32,7 @@ add_service_files(
     ContainsGait.srv
     CurrentState.srv
     PossibleGaits.srv
-    StringTrigger.srv
-    Trigger.srv
+    SetGaitVersion.srv
 )
 
 add_action_files(

--- a/march_shared_resources/srv/SetGaitVersion.srv
+++ b/march_shared_resources/srv/SetGaitVersion.srv
@@ -1,0 +1,8 @@
+# Service for setting subgait versions of a gait.
+
+string gait
+string[] subgaits
+string[] versions
+---
+bool success
+string message

--- a/march_shared_resources/srv/StringTrigger.srv
+++ b/march_shared_resources/srv/StringTrigger.srv
@@ -1,4 +1,0 @@
-string string
----
-bool success   # indicate a successful run of triggered service
-string message # possible error messages

--- a/march_shared_resources/srv/Trigger.srv
+++ b/march_shared_resources/srv/Trigger.srv
@@ -1,3 +1,0 @@
----
-bool success   # indicate a successful run of triggered service
-string message # possible error messages

--- a/march_state_machine/src/march_state_machine/state_machines/transition_state_machine.py
+++ b/march_state_machine/src/march_state_machine/state_machines/transition_state_machine.py
@@ -2,8 +2,8 @@ import ast
 
 import rospy
 import smach
+from std_srvs.srv import Trigger
 
-from march_shared_resources.srv import Trigger
 from march_state_machine.states.transition_state import TransitionState
 
 


### PR DESCRIPTION
Closes PM-445

## Description
In this PR I have changed the `set_version_map` service to `set_gait_version` service. The main difference is that the new version only sets specific versions of a single gait instead of setting all gait versions. See the new `SetGaitVersion.srv` description for more info. However, in order to make this implementation efficient I had to refactor most of the `GaitSelection` and `Gait` classes. The biggest change is that the array of gaits in `GaitSelection` changed from a list to a dictionary, mapping gait names to gait instances. This made it much easier to implement what I needed and more efficient. Furthermore, for the `Gait` class I have changed something similar. The subgaits array is now a dictionary, mapping subgait names to subgait instances. I also found a bug where subgaits would be **loaded multiple times** :exploding_head: , because it would load all subgaits from the graph, which could contain duplicates. I had to also change the way gaits and subgaits were loaded a bit in order to make it work. Finally, the new functionality is built in as a method on the `Gait` class which allows you to change subgait versions.

## Changes
* Added new `SetGaitVersion.srv` service descriptionn
* Changed `set_version_map` service to `set_gait_version` service
* Refactored `GaitSelection` and `Gait` classes in order to fit the new functionality
* Added `set_gait_version` methods on `GaitSelection` and `Gait`
* Added new tests