### PR TITLE
Feature/pm 509 interpolate subgaits with parameter

### DIFF
--- a/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
+++ b/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
@@ -62,7 +62,7 @@ class TransitionError(Exception):
         super(TransitionError, self).__init__(msg)
 
 
-class SubGaitInterpolationError(Exception):
+class SubgaitInterpolationError(Exception):
     def __init__(self, msg=None):
         """Class to raise an error when it was not possible to interpolate between subgaits."""
         if msg is None:

--- a/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
+++ b/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
@@ -68,4 +68,4 @@ class SubgaitInterpolationError(Exception):
         if msg is None:
             msg = 'An error occurred while trying to merge two subgaits.'
 
-        super(SubGaitInterpolationError, self).__init__(msg)
+        super(SubgaitInterpolationError, self).__init__(msg)

--- a/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
+++ b/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
@@ -60,3 +60,12 @@ class TransitionError(Exception):
             msg = 'Subgaits can not transition'
 
         super(TransitionError, self).__init__(msg)
+
+
+class SubGaitInterpolationError(Exception):
+    def __init__(self, msg=None):
+        """Class to raise an error when it was not possible to interpolate between subgaits."""
+        if msg is None:
+            msg = 'An error occurred while trying to merge two subgaits.'
+
+        super(SubGaitInterpolationError, self).__init__(msg)

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -153,6 +153,6 @@ class JointTrajectory(object):
             raise SubgaitInterpolationError('The amount of setpoints do not match for joint {0}'.
                                             format(base_trajectory.name))
         for base_setpoint, other_setpoint in zip(base_trajectory.setpoints, other_trajectory.setpoints):
-            setpoints.append(cls.setpoint_class.interpolate_setpoints(base_setpoint, other_setpoint))
+            setpoints.append(cls.setpoint_class.interpolate_setpoints(base_setpoint, other_setpoint, parameter))
         duration = parameter * base_trajectory.duration + (1 - parameter) * other_trajectory.duration
         return JointTrajectory(base_trajectory.name, base_trajectory.limits, setpoints, duration)

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -145,9 +145,6 @@ class JointTrajectory(object):
 
     @classmethod
     def interpolate_joint_trajectories(cls, base_trajectory, other_trajectory, parameter):
-        if base_trajectory.name != other_trajectory.name:
-            raise SubgaitInterpolationError('Not able to safely interpolate because the names do not match, base is {0}'
-                                            ', other is {1}'.format(base_trajectory.name, other_trajectory.name))
         if base_trajectory.limits != other_trajectory.limits:
             raise SubgaitInterpolationError('Not able to safely interpolate because limits are not equal for joint {0}'.
                                             format(base_trajectory.name))

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -152,6 +152,6 @@ class JointTrajectory(object):
             raise SubgaitInterpolationError('The amount of setpoints do not match for joint {0}'.
                                             format(base_trajectory.name))
         for base_setpoint, other_setpoint in zip(base_trajectory.setpoints, other_trajectory.setpoints):
-            setpoints.append(cls.setpoint_class.interpolate_setpoint(base_setpoint, other_setpoint))
+            setpoints.append(cls.setpoint_class.interpolate_setpoints(base_setpoint, other_setpoint))
         duration = parameter * base_trajectory.duration + (1 - parameter) * other_trajectory.duration
         return JointTrajectory(base_trajectory.name, base_trajectory.limits, setpoints, duration)

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -145,13 +145,16 @@ class JointTrajectory(object):
 
     @classmethod
     def interpolate_joint_trajectories(cls, base_trajectory, other_trajectory, parameter):
+        if base_trajectory.name != other_trajectory.name:
+            raise SubgaitInterpolationError('Not able to safely interpolate because the names do not match, base is {0}'
+                                            ', other is {1}'.format(base_trajectory.name, other_trajectory.name))
         if base_trajectory.limits != other_trajectory.limits:
             raise SubgaitInterpolationError('Not able to safely interpolate because limits are not equal for joint {0}'.
                                             format(base_trajectory.name))
-        setpoints = []
         if len(base_trajectory.setpoints) != len(other_trajectory.setpoints):
             raise SubgaitInterpolationError('The amount of setpoints do not match for joint {0}'.
                                             format(base_trajectory.name))
+        setpoints = []
         for base_setpoint, other_setpoint in zip(base_trajectory.setpoints, other_trajectory.setpoints):
             setpoints.append(cls.setpoint_class.interpolate_setpoints(base_setpoint, other_setpoint, parameter))
         duration = parameter * base_trajectory.duration + (1 - parameter) * other_trajectory.duration

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -145,6 +145,18 @@ class JointTrajectory(object):
 
     @classmethod
     def interpolate_joint_trajectories(cls, base_trajectory, other_trajectory, parameter):
+        """Linearly interpolate two joint trajectories with the parameter.
+
+        :param base_trajectory:
+            base trajectory, return value if parameter is equal to zero
+        :param other_trajectory:
+            other trajectory, return value if parameter is equal to one
+        :param parameter:
+            The parameter to use for interpolation. Should be 0 <= parameter <= 1
+
+        :return:
+            The interpolated trajectory
+        """
         if base_trajectory.limits != other_trajectory.limits:
             raise SubgaitInterpolationError('Not able to safely interpolate because limits are not equal for joint {0}'.
                                             format(base_trajectory.name))

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -1,6 +1,8 @@
 import rospy
 from scipy.interpolate import BPoly
 
+
+from march_shared_classes.exceptions.gait_exceptions import SubgaitInterpolationError
 from .setpoint import Setpoint
 
 
@@ -143,9 +145,8 @@ class JointTrajectory(object):
     @classmethod
     def interpolate_joint_trajectories(cls, base_trajectory, other_trajectory, parameter):
         if base_trajectory.limits != other_trajectory.limits:
-            rospy.logwarn('Not able to safely interpolate because limits are not equal for joint {0}'.format(
+            raise SubgaitInterpolationError('Not able to safely interpolate because limits are not equal for joint {0}'.format(
                 base_trajectory.name))
-            return None
         setpoints = []
         for base_setpoint, other_setpoint in zip(base_trajectory.setpoints, other_trajectory.setpoints):
             setpoints.append(cls.setpoint_class.interpolate_setpoint(base_setpoint, other_setpoint))

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -139,3 +139,15 @@ class JointTrajectory(object):
 
     def __len__(self):
         return len(self.setpoints)
+
+    @classmethod
+    def interpolate_joint_trajectories(cls, base_trajectory, other_trajectory, parameter):
+        if base_trajectory.limits != other_trajectory.limits:
+            rospy.logwarn('Not able to safely interpolate because limits are not equal for joint {0}'.format(
+                base_trajectory.name))
+            return None
+        setpoints = []
+        for base_setpoint, other_setpoint in zip(base_trajectory.setpoints, other_trajectory.setpoints):
+            setpoints.append(cls.setpoint_class.interpolate_setpoint(base_setpoint, other_setpoint))
+        duration = parameter * base_trajectory.duration + (1 - parameter) * other_trajectory.duration
+        return JointTrajectory(base_trajectory.name, base_trajectory.limits, setpoints, duration)

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -1,8 +1,8 @@
 import rospy
 from scipy.interpolate import BPoly
 
-
 from march_shared_classes.exceptions.gait_exceptions import SubgaitInterpolationError
+
 from .setpoint import Setpoint
 
 
@@ -145,9 +145,12 @@ class JointTrajectory(object):
     @classmethod
     def interpolate_joint_trajectories(cls, base_trajectory, other_trajectory, parameter):
         if base_trajectory.limits != other_trajectory.limits:
-            raise SubgaitInterpolationError('Not able to safely interpolate because limits are not equal for joint {0}'.format(
-                base_trajectory.name))
+            raise SubgaitInterpolationError('Not able to safely interpolate because limits are not equal for joint {0}'.
+                                            format(base_trajectory.name))
         setpoints = []
+        if len(base_trajectory.setpoints) != len(other_trajectory.setpoints):
+            raise SubgaitInterpolationError('The amount of setpoints do not match for joint {0}'.
+                                            format(base_trajectory.name))
         for base_setpoint, other_setpoint in zip(base_trajectory.setpoints, other_trajectory.setpoints):
             setpoints.append(cls.setpoint_class.interpolate_setpoint(base_setpoint, other_setpoint))
         duration = parameter * base_trajectory.duration + (1 - parameter) * other_trajectory.duration

--- a/march_shared_classes/src/march_shared_classes/gait/limits.py
+++ b/march_shared_classes/src/march_shared_classes/gait/limits.py
@@ -7,3 +7,11 @@ class Limits(object):
         self.effort = effort
         self.k_position = k_position
         self.k_velocity = k_velocity
+
+    def __eq__(self, other):
+        return self.lower == other.lower and self.upper == other.upper and self.velocity == other.velocity and  \
+               self.effort == other.effort and self.k_position == other.k_position and \
+               self.k_velocity == other.k_velocity
+
+    def __ne__(self, other):
+        return not self == other

--- a/march_shared_classes/src/march_shared_classes/gait/limits.py
+++ b/march_shared_classes/src/march_shared_classes/gait/limits.py
@@ -10,8 +10,8 @@ class Limits(object):
 
     def __eq__(self, other):
         return self.lower == other.lower and self.upper == other.upper and self.velocity == other.velocity and  \
-               self.effort == other.effort and self.k_position == other.k_position and \
-               self.k_velocity == other.k_velocity
+            self.effort == other.effort and self.k_position == other.k_position and \
+            self.k_velocity == other.k_velocity
 
     def __ne__(self, other):
         return not self == other

--- a/march_shared_classes/src/march_shared_classes/gait/setpoint.py
+++ b/march_shared_classes/src/march_shared_classes/gait/setpoint.py
@@ -46,3 +46,10 @@ class Setpoint(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    @staticmethod
+    def interpolate_setpoint(base_setpoint, other_setpoint, parameter):
+        time = parameter * base_setpoint.time + (1 - parameter) * other_setpoint.time
+        position = parameter * base_setpoint.position + (1 - parameter) * other_setpoint.position
+        velocity = parameter * base_setpoint.velocity + (1 - parameter) * other_setpoint.velocity
+        return Setpoint(time, position, velocity)

--- a/march_shared_classes/src/march_shared_classes/gait/setpoint.py
+++ b/march_shared_classes/src/march_shared_classes/gait/setpoint.py
@@ -49,6 +49,17 @@ class Setpoint(object):
 
     @staticmethod
     def interpolate_setpoints(base_setpoint, other_setpoint, parameter):
+        """Linearly interpolate two setpoints.
+
+        :param base_setpoint:
+            base setpoint, return value if parameter is zero
+        :param other_setpoint:
+            other setpoint, return value if parameter is one
+        :param parameter:
+            parameter for linear interpolation, 0 <= parameter <= 1
+        :return:
+            The interpolated setpoint
+        """
         time = parameter * base_setpoint.time + (1 - parameter) * other_setpoint.time
         position = parameter * base_setpoint.position + (1 - parameter) * other_setpoint.position
         velocity = parameter * base_setpoint.velocity + (1 - parameter) * other_setpoint.velocity

--- a/march_shared_classes/src/march_shared_classes/gait/setpoint.py
+++ b/march_shared_classes/src/march_shared_classes/gait/setpoint.py
@@ -48,7 +48,7 @@ class Setpoint(object):
         return not self.__eq__(other)
 
     @staticmethod
-    def interpolate_setpoint(base_setpoint, other_setpoint, parameter):
+    def interpolate_setpoints(base_setpoint, other_setpoint, parameter):
         time = parameter * base_setpoint.time + (1 - parameter) * other_setpoint.time
         position = parameter * base_setpoint.position + (1 - parameter) * other_setpoint.position
         velocity = parameter * base_setpoint.velocity + (1 - parameter) * other_setpoint.velocity

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -251,7 +251,11 @@ class Subgait(object):
                                                 base_subgait.joints), len(other_subgait.joints)))
         joints = []
         try:
-            for base_joint, other_joint in zip(base_subgait.joints, other_subgait.joints):
+            for base_joint in base_subgait.joints:
+                other_joint = other_subgait.get_joint(base_joint.name)
+                if other_joint is None:
+                    raise SubgaitInterpolationError('Could not find a matching joint for base joint with name {0}.'.
+                                                    format(base_joint.name))
                 joints.append(cls.joint_class.interpolate_joint_trajectories(base_joint, other_joint, parameter))
         except SubgaitInterpolationError as e:
             raise e

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -240,28 +240,24 @@ class Subgait(object):
         if parameter == 0:
             return base_subgait
         if not (0 < parameter < 1):
-            raise SubgaitInterpolationError('Parameter for interpolation should be in the interval [0, 1], but is {0}'
-                                            .format(parameter))
+            raise ValueError('Parameter for interpolation should be in the interval [0, 1], but is {0}'
+                             .format(parameter))
 
         if len(base_subgait.joints) != len(other_subgait.joints):
-            raise SubgaitInterpolationError('The subgaits to interpolate do not ahve an equal amount of joints, base'
+            raise SubgaitInterpolationError('The subgaits to interpolate do not have an equal amount of joints, base'
                                             ' subgait has {0}, while other subgait has {1}'.format(len(
                                                 base_subgait.joints), len(other_subgait.joints)))
-        duration = base_subgait.duration * parameter + (1 - parameter) * other_subgait.duration
         joints = []
         try:
             for base_joint, other_joint in zip(base_subgait.joints, other_subgait.joints):
-                if base_joint.name == other_joint.name:
-                    joints.append(cls.joint_class.interpolate_joint_trajectories(base_joint, other_joint, parameter))
-                else:
-                    raise SubgaitInterpolationError('Joint names do not match joint in base_subgait is {0} and in the '
-                                                    'other subgait is {1}'.format(base_joint.name, other_joint.name))
+                joints.append(cls.joint_class.interpolate_joint_trajectories(base_joint, other_joint, parameter))
         except SubgaitInterpolationError as e:
             raise e
 
         description = 'Interpolation between base version {0}, and other version {1} with parameter{2}'.format(
             base_subgait.version, other_subgait.version, parameter)
 
+        duration = base_subgait.duration * parameter + (1 - parameter) * other_subgait.duration
         return Subgait(joints, duration, base_subgait.gait_name, base_subgait.subgait_name, 'interpolated subgait',
                        description)
     # endregion

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -227,6 +227,30 @@ class Subgait(object):
 
             joint.setpoints = new_joint_setpoints
 
+    @classmethod
+    def interpolate_subgaits(cls, base_subgait, other_subgait, parameter):
+        if parameter == 1:
+            return other_subgait
+        if parameter == 0:
+            return base_subgait
+        if not (0 < parameter < 1):
+            #error
+            return None
+
+        if len(base_subgait.joints) != len(other_subgait.joints):
+            #error
+            return None
+        duration = base_subgait.duration * parameter + (1 - parameter) * other_subgait.duration
+        joints = []
+        for base_joint, other_joint in zip(base_subgait.joints, other_subgait.joints):
+            if base_joint.name==other_joint.name:
+                joints.append(cls.joint_class.interpolate_joint_trajectories(base_joint, other_joint, parameter))
+        description = 'Interpolation between base version {0}, and other version {1} with parameter{2}'.format(
+            base_subgait.version, other_subgait.version, parameter)
+
+        return Subgait(joints, duration, base_subgait.gait_name, base_subgait.subgait_name, 'interpolated subgait', description)
+
+
     # endregion
 
     # region Get functions

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -10,7 +10,7 @@ from march_shared_resources import msg as march_msg
 
 
 class Subgait(object):
-    """Base class for usage of the defined sub gaits."""
+    """Base class for usage of the defined subgaits."""
 
     joint_class = JointTrajectory
 
@@ -32,9 +32,9 @@ class Subgait(object):
         """Extract sub gait data of the given yaml.
 
         :param robot:
-            The robot corresponding to the given sub-gait file
+            The robot corresponding to the given subgait file
         :param file_name:
-            The .yaml file name of the sub gait
+            The .yaml file name of the subgait
 
         :returns
             A populated Subgait object
@@ -58,6 +58,19 @@ class Subgait(object):
 
     @classmethod
     def from_files_interpolated(cls, robot, file_name_base, file_name_other, parameter, *args):
+        """Extract two subgaits from files and interpolate.
+
+        :param robot:
+            The robot corresponding to the given subgait file
+        :param file_name_base:
+            The .yaml file name of the base subgait
+        :param file_name_other:
+        :param parameter:
+            The parameter to use for interpolation. Should be 0 <= parameter <= 1
+
+        :return:
+            A populated Subgait object
+        """
         base_subgait = cls.from_file(robot, file_name_base, *args)
         other_subgait = cls.from_file(robot, file_name_other, *args)
         return cls.interpolate_subgaits(base_subgait, other_subgait, parameter)
@@ -237,6 +250,18 @@ class Subgait(object):
 
     @classmethod
     def interpolate_subgaits(cls, base_subgait, other_subgait, parameter):
+        """Linearly interpolate two subgaits with the parameter to get a new subgait.
+
+        :param base_subgait:
+            base subgait, return value if parameter is equal to zero
+        :param other_subgait:
+            other subgait, return value if parameter is equal to one
+        :param parameter:
+            The parameter to use for interpolation. Should be 0 <= parameter <= 1
+
+        :return:
+            The interpolated subgait
+        """
         if parameter == 1:
             return other_subgait
         if parameter == 0:
@@ -245,10 +270,11 @@ class Subgait(object):
             raise ValueError('Parameter for interpolation should be in the interval [0, 1], but is {0}'
                              .format(parameter))
 
-        if len(base_subgait.joints) != len(other_subgait.joints):
-            raise SubgaitInterpolationError('The subgaits to interpolate do not have an equal amount of joints, base'
-                                            ' subgait has {0}, while other subgait has {1}'.format(len(
-                                                base_subgait.joints), len(other_subgait.joints)))
+        if sorted(base_subgait.get_joint_names()) != sorted(other_subgait.get_joint_names()):
+            raise SubgaitInterpolationError('The subgaits to interpolate do not have the same joints, base'
+                                            ' subgait has {0}, while other subgait has {1}'.
+                                            format(sorted(base_subgait.get_joint_names()),
+                                                          sorted(other_subgait.get_joint_names())))
         joints = []
         try:
             for base_joint in base_subgait.joints:

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -239,22 +239,25 @@ class Subgait(object):
 
         if len(base_subgait.joints) != len(other_subgait.joints):
             raise SubgaitInterpolationError('The subgaits to interpolate do not ahve an equal amount of joints, base'
-                                            ' subgait has {0}, while other subgait has {1}'.format(len(base_subgait.joints), len(other_subgait.joints))
+                                            ' subgait has {0}, while other subgait has {1}'.format(len(
+                                                base_subgait.joints), len(other_subgait.joints)))
         duration = base_subgait.duration * parameter + (1 - parameter) * other_subgait.duration
         joints = []
         try:
             for base_joint, other_joint in zip(base_subgait.joints, other_subgait.joints):
-                if base_joint.name==other_joint.name:
+                if base_joint.name == other_joint.name:
                     joints.append(cls.joint_class.interpolate_joint_trajectories(base_joint, other_joint, parameter))
+                else:
+                    raise SubgaitInterpolationError('Joint names do not match joint in base_subgait is {0} and in the '
+                                                    'other subgait is {1}'.format(base_joint.name, other_joint.name))
         except SubgaitInterpolationError as e:
             raise e
 
         description = 'Interpolation between base version {0}, and other version {1} with parameter{2}'.format(
             base_subgait.version, other_subgait.version, parameter)
 
-        return Subgait(joints, duration, base_subgait.gait_name, base_subgait.subgait_name, 'interpolated subgait', description)
-
-
+        return Subgait(joints, duration, base_subgait.gait_name, base_subgait.subgait_name, 'interpolated subgait',
+                       description)
     # endregion
 
     # region Get functions

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -57,6 +57,12 @@ class Subgait(object):
         return cls.from_dict(robot, subgait_dict, gait_name, subgait_name, version, *args)
 
     @classmethod
+    def from_files_interpolated(cls, robot, file_name_base, file_name_other, parameter, *args):
+        base_subgait = cls.from_file(robot, file_name_base, *args)
+        other_subgait = cls.from_file(robot, file_name_other, *args)
+        return cls.interpolate_subgaits(base_subgait, other_subgait, parameter)
+
+    @classmethod
     def from_dict(cls, robot, subgait_dict, gait_name, subgait_name, version, *args):
         """List parameters from the yaml file in organized lists.
 

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -274,7 +274,7 @@ class Subgait(object):
             raise SubgaitInterpolationError('The subgaits to interpolate do not have the same joints, base'
                                             ' subgait has {0}, while other subgait has {1}'.
                                             format(sorted(base_subgait.get_joint_names()),
-                                                          sorted(other_subgait.get_joint_names())))
+                                                   sorted(other_subgait.get_joint_names())))
         joints = []
         try:
             for base_joint in base_subgait.joints:

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -99,3 +99,12 @@ class JointTrajectoryTest(unittest.TestCase):
                                            self.duration)
         with self.assertRaises(SubgaitInterpolationError):
             JointTrajectory.interpolate_joint_trajectories(self.joint_trajectory, other_trajectory, 0.5)
+
+    def test_interpolate_trajectories_correct_duration(self):
+        parameter = 0.5
+        other_duration = self.setpoints[2].time
+        other_trajectory = JointTrajectory(self.joint_name, self.limits, [self.setpoints[0], self.setpoints[2]],
+                                           other_duration)
+        new_trajectory = JointTrajectory.interpolate_joint_trajectories(self.joint_trajectory, other_trajectory,
+                                                                        parameter)
+        self.assertEqual(new_trajectory.duration, self.duration * parameter + (1 - parameter) * other_duration)

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from march_shared_classes.exceptions.gait_exceptions import SubgaitInterpolationError
 from march_shared_classes.gait.joint_trajectory import JointTrajectory
 from march_shared_classes.gait.limits import Limits
 from march_shared_classes.gait.setpoint import Setpoint
@@ -79,3 +80,15 @@ class JointTrajectoryTest(unittest.TestCase):
         self.joint_trajectory.setpoints = [Setpoint(3, 1, 1)]
         setpoint = self.joint_trajectory.get_interpolated_setpoint(1)
         self.assertEqual(setpoint, Setpoint(1, 1, 1))
+
+    def test_interpolate_trajectories_unequal_limits(self):
+        different_limits = Limits(-2, 3, 2)
+        other_trajectory = JointTrajectory(self.joint_name, different_limits, self.setpoints, self.duration)
+        with self.assertRaises(SubgaitInterpolationError):
+            JointTrajectory.interpolate_joint_trajectories(self.joint_trajectory, other_trajectory, 0.5)
+
+    def test_interpolate_trajectories_unequal_amount_setpoints(self):
+        other_trajectory = JointTrajectory(self.joint_name, self.limits, [self.setpoints[0], self.setpoints[0]],
+                                           self.duration)
+        with self.assertRaises(SubgaitInterpolationError):
+            JointTrajectory.interpolate_joint_trajectories(self.joint_trajectory, other_trajectory, 0.5)

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -95,7 +95,7 @@ class JointTrajectoryTest(unittest.TestCase):
             JointTrajectory.interpolate_joint_trajectories(self.joint_trajectory, other_trajectory, 0.5)
 
     def test_interpolate_trajectories_unequal_amount_setpoints(self):
-        other_trajectory = JointTrajectory(self.joint_name, self.limits, [self.setpoints[0], self.setpoints[0]],
+        other_trajectory = JointTrajectory(self.joint_name, self.limits, [self.setpoints[0], self.setpoints[-1]],
                                            self.duration)
         with self.assertRaises(SubgaitInterpolationError):
             JointTrajectory.interpolate_joint_trajectories(self.joint_trajectory, other_trajectory, 0.5)

--- a/march_shared_classes/test/joint_trajectory_test.py
+++ b/march_shared_classes/test/joint_trajectory_test.py
@@ -102,8 +102,10 @@ class JointTrajectoryTest(unittest.TestCase):
 
     def test_interpolate_trajectories_correct_duration(self):
         parameter = 0.5
-        other_duration = self.setpoints[2].time
-        other_trajectory = JointTrajectory(self.joint_name, self.limits, [self.setpoints[0], self.setpoints[2]],
+        other_duration = self.duration + 1
+        other_times = [0, other_duration / 2.0, other_duration]
+        other_setpoints = [Setpoint(t, 2 * t, t / 2.0) for t in other_times]
+        other_trajectory = JointTrajectory(self.joint_name, self.limits, other_setpoints,
                                            other_duration)
         new_trajectory = JointTrajectory.interpolate_joint_trajectories(self.joint_trajectory, other_trajectory,
                                                                         parameter)

--- a/march_shared_classes/test/limits_test.py
+++ b/march_shared_classes/test/limits_test.py
@@ -28,6 +28,26 @@ class LimitsTest(unittest.TestCase):
     def test_equal_operator(self):
         self.assertEqual(self.limits, Limits(0, 1, 2, 3, 4, 5))
 
-    def test_unequal_operator(self):
+    def test_unequal_operator_1(self):
         # first entry different
         self.assertNotEqual(self.limits, Limits(1, 1, 2, 3, 4, 5))
+
+    def test_unequal_operator_2(self):
+        # second entry different
+        self.assertNotEqual(self.limits, Limits(0, 2, 2, 3, 4, 5))
+
+    def test_unequal_operator_3(self):
+        # third entry different
+        self.assertNotEqual(self.limits, Limits(0, 1, 3, 3, 4, 5))
+
+    def test_unequal_operator_4(self):
+        # fourth entry different
+        self.assertNotEqual(self.limits, Limits(0, 1, 2, 4, 4, 5))
+
+    def test_unequal_operator_5(self):
+        # fifth entry different
+        self.assertNotEqual(self.limits, Limits(0, 1, 2, 3, 5, 5))
+
+    def test_unequal_operator(self):
+        # sixth entry different
+        self.assertNotEqual(self.limits, Limits(0, 1, 2, 3, 4, 6))

--- a/march_shared_classes/test/limits_test.py
+++ b/march_shared_classes/test/limits_test.py
@@ -24,3 +24,10 @@ class LimitsTest(unittest.TestCase):
 
     def test_k_velocity(self):
         self.assertEqual(self.limits.k_velocity, 5, 'k_velocity not initialised correctly.')
+
+    def test_equal_operator(self):
+        self.assertEqual(self.limits, Limits(0, 1, 2, 3, 4, 5))
+
+    def test_unequal_operator(self):
+        # first entry different
+        self.assertNotEqual(self.limits, Limits(1, 1, 2, 3, 4, 5))

--- a/march_shared_classes/test/resources/walk/left_close/MV_walk_leftclose_v2_wrong_joint_name.subgait
+++ b/march_shared_classes/test/resources/walk/left_close/MV_walk_leftclose_v2_wrong_joint_name.subgait
@@ -1,0 +1,112 @@
+name: ''
+version: ''
+description: "Final left step of the MIV walking gait."
+gait_type: "walk_like"
+setpoints: 
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs:         0
+    joint_names: [wrong_joint_name, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 496000000
+    joint_names: [left_knee]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 581200000
+    joint_names: [wrong_joint_name, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 620000000
+    joint_names: [left_hip_fe]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 775000000
+    joint_names: [wrong_joint_name, right_hip_aa]
+  - 
+    time_from_start: 
+      secs: 0
+      nsecs: 930000000
+    joint_names: [right_hip_fe]
+  - 
+    time_from_start: 
+      secs: 1
+      nsecs: 550000000
+    joint_names: [wrong_joint_name, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+trajectory: 
+  header: 
+    seq: 0
+    stamp: 
+      secs: 0
+      nsecs:         0
+    frame_id: ''
+  joint_names: [wrong_joint_name, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
+  right_ankle]
+  points: 
+    - 
+      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
+      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs:         0
+    - 
+      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062, 0.0436]
+      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.2837, -0.1166, 0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 496000000
+    - 
+      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964, 0.0436]
+      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2479, -0.1255, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 581200000
+    - 
+      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912, 0.0436]
+      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2274, -0.1289, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 620000000
+    - 
+      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698, 0.0436]
+      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 775000000
+    - 
+      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
+      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 0
+        nsecs: 930000000
+    - 
+      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
+      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      accelerations: []
+      effort: []
+      time_from_start: 
+        secs: 1
+        nsecs: 550000000
+duration: 
+  secs: 1
+  nsecs: 550000000
+sounds: []

--- a/march_shared_classes/test/setpoint_test.py
+++ b/march_shared_classes/test/setpoint_test.py
@@ -42,6 +42,6 @@ class SetpointTest(unittest.TestCase):
     def test_interpolation_correct(self):
         parameter = 0.3
         other_setpoint = Setpoint(1, 1, 1)
-        expected_result = Setpoint(parameter * 1.1234 + (1- parameter) * 1, 0.03434 * parameter + (1 - parameter) * 1,
+        expected_result = Setpoint(parameter * 1.1234 + (1 - parameter) * 1, 0.03434 * parameter + (1 - parameter) * 1,
                                    123.1620 * parameter + (1 - parameter) * 1)
         self.assertEqual(expected_result, Setpoint.interpolate_setpoints(self.setpoint, other_setpoint, parameter))

--- a/march_shared_classes/test/setpoint_test.py
+++ b/march_shared_classes/test/setpoint_test.py
@@ -35,6 +35,13 @@ class SetpointTest(unittest.TestCase):
         other_setpoint = Setpoint(1.1234, -0.0343, 123.1621)
         self.assertNotEqual(self.setpoint, other_setpoint)
 
-    def test_eunqual_velocity(self):
+    def test_unequal_velocity(self):
         other_setpoint = Setpoint(1.1234, 0.0343, 0)
         self.assertNotEqual(self.setpoint, other_setpoint)
+
+    def test_interpolation_correct(self):
+        parameter = 0.3
+        other_setpoint = Setpoint(1, 1, 1)
+        expected_result = Setpoint(parameter * 1.1234 + (1- parameter) * 1, 0.03434 * parameter + (1 - parameter) * 1,
+                                   123.1620 * parameter + (1 - parameter) * 1)
+        self.assertEqual(expected_result, Setpoint.interpolate_setpoints(self.setpoint, other_setpoint, parameter))

--- a/march_shared_classes/test/setpoint_test.py
+++ b/march_shared_classes/test/setpoint_test.py
@@ -42,6 +42,7 @@ class SetpointTest(unittest.TestCase):
     def test_interpolation_correct(self):
         parameter = 0.3
         other_setpoint = Setpoint(1, 1, 1)
-        expected_result = Setpoint(parameter * 1.1234 + (1 - parameter) * 1, 0.03434 * parameter + (1 - parameter) * 1,
-                                   123.1620 * parameter + (1 - parameter) * 1)
+        expected_result = Setpoint(parameter * self.setpoint.time + (1 - parameter) * 1,
+                                   self.setpoint.position * parameter + (1 - parameter) * 1,
+                                   self.setpoint.velocity * parameter + (1 - parameter) * 1)
         self.assertEqual(expected_result, Setpoint.interpolate_setpoints(self.setpoint, other_setpoint, parameter))

--- a/march_shared_classes/test/setpoint_test.py
+++ b/march_shared_classes/test/setpoint_test.py
@@ -42,7 +42,7 @@ class SetpointTest(unittest.TestCase):
     def test_interpolation_correct(self):
         parameter = 0.3
         other_setpoint = Setpoint(1, 1, 1)
-        expected_result = Setpoint(parameter * self.setpoint.time + (1 - parameter) * 1,
+        expected_result = Setpoint(self.setpoint.time * parameter + (1 - parameter) * 1,
                                    self.setpoint.position * parameter + (1 - parameter) * 1,
                                    self.setpoint.velocity * parameter + (1 - parameter) * 1)
         self.assertEqual(expected_result, Setpoint.interpolate_setpoints(self.setpoint, other_setpoint, parameter))

--- a/march_shared_classes/test/subgait_test.py
+++ b/march_shared_classes/test/subgait_test.py
@@ -186,7 +186,7 @@ class SubgaitTest(unittest.TestCase):
         self.assertEqual(other_subgait, new_subgait)
 
     def test_interpolate_subgaits_interpolated(self):
-        # test whether each setpoint of the new subgait is between the setpoins
+        # test whether each setpoint is correctly interpolated
         parameter = 0.4
         base_subgait, other_subgait = self.load_interpolatable_subgaits()
         new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, parameter)
@@ -194,11 +194,12 @@ class SubgaitTest(unittest.TestCase):
             for j, setpoint in enumerate(joint.setpoints):
                 base_setpoint = base_subgait.joints[i].setpoints[j]
                 other_setpoint = other_subgait.joints[i].setpoints[j]
-                self.assertTrue(base_setpoint.time * parameter + (1 - parameter) * other_setpoint.time, setpoint.time)
-                self.assertTrue(base_setpoint.position * parameter + (1 - parameter) * other_setpoint.position,
-                                setpoint.position)
-                self.assertTrue(base_setpoint.velocity * parameter + (1 - parameter) * other_setpoint.velocity,
-                                setpoint.velocity)
+                self.assertAlmostEqual(base_setpoint.time * parameter + (1 - parameter) * other_setpoint.time,
+                                       setpoint.time, places=4)
+                self.assertAlmostEqual(base_setpoint.position * parameter + (1 - parameter) * other_setpoint.position,
+                                       setpoint.position, places=4)
+                self.assertAlmostEqual(base_setpoint.velocity * parameter + (1 - parameter) * other_setpoint.velocity,
+                                       setpoint.velocity, places=4)
 
     def test_interpolate_subgaits_wrong_amount_of_joints(self):
         base_subgait, other_subgait = self.load_interpolatable_subgaits('right_close', 'MV_walk_rightclose_v2',

--- a/march_shared_classes/test/subgait_test.py
+++ b/march_shared_classes/test/subgait_test.py
@@ -35,6 +35,19 @@ class SubgaitTest(unittest.TestCase):
     def test_from_file_no_robot(self):
         self.assertIsNone(Subgait.from_file(None, self.subgait_path))
 
+    # Subgait.from_files_interpolated tests
+    def test_from_files_interpolated_correct(self):
+        base_file_name = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
+                                                                           gait=self.gait_name,
+                                                                           subgait='left_close',
+                                                                           version='MV_walk_leftclose_v1')
+        other_file_name = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
+                                                                            gait=self.gait_name,
+                                                                            subgait='left_close',
+                                                                            version='MV_walk_leftclose_v2')
+        subgait = Subgait.from_files_interpolated(self.robot, base_file_name, other_file_name, 0.5)
+        self.assertIsInstance(subgait, Subgait)
+
     # to_subgait_msg tests
     def test_to_subgait_msg_name(self):
         self.assertEqual(self.subgait_msg.name, self.subgait_name)
@@ -141,7 +154,7 @@ class SubgaitTest(unittest.TestCase):
                              '\nold timestamps: {old} \nnew timestamps: {new}'
                          .format(old=str(timestamps), new=str(self.subgait.get_unique_timestamps())))
 
-    # interpolate_subgaits tests
+    # Subgait.interpolate_subgaits tests
     def load_interpolatable_subgaits(self, subgait_name='left_close', base_version='MV_walk_leftclose_v1',
                                      other_version='MV_walk_leftclose_v2'):
         base_subgait_path = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,

--- a/march_shared_classes/test/subgait_test.py
+++ b/march_shared_classes/test/subgait_test.py
@@ -172,7 +172,7 @@ class SubgaitTest(unittest.TestCase):
     def test_interpolate_subgaits_wrong_parameter(self):
         # should be 0 <= parameter <= 1
         base_subgait, other_subgait = self.load_interpolatable_subgaits()
-        with self.assertRaises(SubgaitInterpolationError):
+        with self.assertRaises(ValueError):
             Subgait.interpolate_subgaits(base_subgait, other_subgait, 2)
 
     def test_interpolate_subgaits_parameter_zero(self):
@@ -186,7 +186,7 @@ class SubgaitTest(unittest.TestCase):
         self.assertEqual(other_subgait, new_subgait)
 
     def test_interpolate_subgaits_interpolated(self):
-        # test whether each setpoint is between the setpoins
+        # test whether each setpoint of the new subgait is between the setpoins
         base_subgait, other_subgait = self.load_interpolatable_subgaits()
         new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, 1)
         for i, joint in enumerate(new_subgait.joints):

--- a/march_shared_classes/test/subgait_test.py
+++ b/march_shared_classes/test/subgait_test.py
@@ -37,15 +37,15 @@ class SubgaitTest(unittest.TestCase):
 
     # Subgait.from_files_interpolated tests
     def test_from_files_interpolated_correct(self):
-        base_file_name = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
-                                                                           gait=self.gait_name,
-                                                                           subgait='left_close',
-                                                                           version='MV_walk_leftclose_v1')
-        other_file_name = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
-                                                                            gait=self.gait_name,
-                                                                            subgait='left_close',
-                                                                            version='MV_walk_leftclose_v2')
-        subgait = Subgait.from_files_interpolated(self.robot, base_file_name, other_file_name, 0.5)
+        base_subgait_path = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
+                                                                              gait=self.gait_name,
+                                                                              subgait='left_close',
+                                                                              version='MV_walk_leftclose_v1')
+        other_subgait_path = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
+                                                                               gait=self.gait_name,
+                                                                               subgait='left_close',
+                                                                               version='MV_walk_leftclose_v2')
+        subgait = Subgait.from_files_interpolated(self.robot, base_subgait_path, other_subgait_path, 0.5)
         self.assertIsInstance(subgait, Subgait)
 
     # to_subgait_msg tests
@@ -187,20 +187,18 @@ class SubgaitTest(unittest.TestCase):
 
     def test_interpolate_subgaits_interpolated(self):
         # test whether each setpoint of the new subgait is between the setpoins
+        parameter = 0.4
         base_subgait, other_subgait = self.load_interpolatable_subgaits()
-        new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, 1)
+        new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, parameter)
         for i, joint in enumerate(new_subgait.joints):
             for j, setpoint in enumerate(joint.setpoints):
                 base_setpoint = base_subgait.joints[i].setpoints[j]
                 other_setpoint = other_subgait.joints[i].setpoints[j]
-                self.assertTrue(min(base_setpoint.time, other_setpoint.time) <= setpoint.time
-                                <= max(base_setpoint.time, other_setpoint.time))
-
-                self.assertTrue(min(base_setpoint.position, other_setpoint.position) <= setpoint.position
-                                <= max(base_setpoint.position, other_setpoint.position))
-
-                self.assertTrue(min(base_setpoint.velocity, other_setpoint.velocity) <= setpoint.velocity
-                                <= max(base_setpoint.velocity, other_setpoint.velocity))
+                self.assertTrue(base_setpoint.time * parameter + (1 - parameter) * other_setpoint.time, setpoint.time)
+                self.assertTrue(base_setpoint.position * parameter + (1 - parameter) * other_setpoint.position,
+                                setpoint.position)
+                self.assertTrue(base_setpoint.velocity * parameter + (1 - parameter) * other_setpoint.velocity,
+                                setpoint.velocity)
 
     def test_interpolate_subgaits_wrong_amount_of_joints(self):
         base_subgait, other_subgait = self.load_interpolatable_subgaits('right_close', 'MV_walk_rightclose_v2',

--- a/march_shared_classes/test/subgait_test.py
+++ b/march_shared_classes/test/subgait_test.py
@@ -3,7 +3,7 @@ import unittest
 import rospkg
 from urdf_parser_py import urdf
 
-from march_shared_classes.exceptions.gait_exceptions import NonValidGaitContent
+from march_shared_classes.exceptions.gait_exceptions import NonValidGaitContent, SubgaitInterpolationError
 from march_shared_classes.gait.joint_trajectory import JointTrajectory
 from march_shared_classes.gait.subgait import Subgait
 
@@ -140,3 +140,70 @@ class SubgaitTest(unittest.TestCase):
                          msg='Scaling the function did not result in same timestamps and equal amount of setpoints'
                              '\nold timestamps: {old} \nnew timestamps: {new}'
                          .format(old=str(timestamps), new=str(self.subgait.get_unique_timestamps())))
+
+    # interpolate_subgaits tests
+    def load_interpolatable_subgaits(self, subgait_name='left_close', base_version='MV_walk_leftclose_v1',
+                                     other_version='MV_walk_leftclose_v2'):
+        base_subgait_path = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
+                                                                              gait=self.gait_name,
+                                                                              subgait=subgait_name,
+                                                                              version=base_version)
+        base_subgait = Subgait.from_file(self.robot, base_subgait_path)
+        other_subgait_path = '{rsc}/{gait}/{subgait}/{version}.subgait'.format(rsc=self.resources_folder,
+                                                                               gait=self.gait_name,
+                                                                               subgait=subgait_name,
+                                                                               version=other_version)
+        other_subgait = Subgait.from_file(self.robot, other_subgait_path)
+        return base_subgait, other_subgait
+
+    def test_interpolate_subgaits_wrong_parameter(self):
+        # should be 0 <= parameter <= 1
+        base_subgait, other_subgait = self.load_interpolatable_subgaits()
+        with self.assertRaises(SubgaitInterpolationError):
+            Subgait.interpolate_subgaits(base_subgait, other_subgait, 2)
+
+    def test_interpolate_subgaits_parameter_zero(self):
+        base_subgait, other_subgait = self.load_interpolatable_subgaits()
+        new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, 0)
+        self.assertEqual(base_subgait, new_subgait)
+
+    def test_interpolate_subgaits_parameter_one(self):
+        base_subgait, other_subgait = self.load_interpolatable_subgaits()
+        new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, 1)
+        self.assertEqual(other_subgait, new_subgait)
+
+    def test_interpolate_subgaits_interpolated(self):
+        # test whether each setpoint is between the setpoins
+        base_subgait, other_subgait = self.load_interpolatable_subgaits()
+        new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, 1)
+        for i, joint in enumerate(new_subgait.joints):
+            for j, setpoint in enumerate(joint.setpoints):
+                base_setpoint = base_subgait.joints[i].setpoints[j]
+                other_setpoint = other_subgait.joints[i].setpoints[j]
+                self.assertTrue(min(base_setpoint.time, other_setpoint.time) <= setpoint.time
+                                <= max(base_setpoint.time, other_setpoint.time))
+
+                self.assertTrue(min(base_setpoint.position, other_setpoint.position) <= setpoint.position
+                                <= max(base_setpoint.position, other_setpoint.position))
+
+                self.assertTrue(min(base_setpoint.velocity, other_setpoint.velocity) <= setpoint.velocity
+                                <= max(base_setpoint.velocity, other_setpoint.velocity))
+
+    def test_interpolate_subgaits_wrong_amount_of_joints(self):
+        base_subgait, other_subgait = self.load_interpolatable_subgaits('right_close', 'MV_walk_rightclose_v2',
+                                                                        'MV_walk_rightclose_v2_seven_joints')
+        with self.assertRaises(SubgaitInterpolationError):
+            Subgait.interpolate_subgaits(base_subgait, other_subgait, 0.5)
+
+    def test_interpolate_subgaits_wrong_joint_names(self):
+        base_subgait, other_subgait = self.load_interpolatable_subgaits(
+            other_version='MV_walk_leftclose_v2_wrong_joint_name')
+        with self.assertRaises(SubgaitInterpolationError):
+            Subgait.interpolate_subgaits(base_subgait, other_subgait, 0.5)
+
+    def test_interpolate_subgaits_duration(self):
+        base_subgait, other_subgait = self.load_interpolatable_subgaits()
+        parameter = 0.2
+        new_subgait = Subgait.interpolate_subgaits(base_subgait, other_subgait, parameter)
+        new_duration = parameter * base_subgait.duration + (1 - parameter) * other_subgait.duration
+        self.assertEqual(new_duration, new_subgait.duration)


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-509

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
We want to able to interpolate two subgaits with a parameter to obtain a new subgait. This PR implements methods in the Subgait, JointTrajectory and Setpoint classes to do so. I also added a function which can load two subgait files and interpolate them. The functions are not used currrently, but in a new issue the 'gait selection', 'default.yaml' and the 'rqt_gait_selection' should be updated to make use of these functions. The functions are tested though as I wrote tests for the Subgait, JointTrajectory, Setpoint and Limits classes.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
* Added interpolation methods for Subgait, JointTrajectory and Setpoint classes
* Added (un)equals operator for the limits
* Added function to load two subgaits and interpolate them
* Added 'SubgaitInterpolationError' for when subgaits differed to much to interpolate
* Added tests to test the new functionality.
<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
