### PR TITLE
Fix/Error naming in the gait and subgait classes

### DIFF
--- a/march_gait_selection/src/march_gait_selection/dynamic_gaits/transition_subgait.py
+++ b/march_gait_selection/src/march_gait_selection/dynamic_gaits/transition_subgait.py
@@ -75,10 +75,10 @@ class TransitionSubgait(Subgait):
         new_subgait = deepcopy(new_gait[new_subgait_name])
 
         if old_subgait is None:
-            raise SubgaitNameNotFound(subgait_name=old_subgait_name)
+            raise SubgaitNameNotFound(old_subgait_name, 'transition_gait')
 
         if new_subgait is None:
-            raise SubgaitNameNotFound(subgait_name=new_subgait_name)
+            raise SubgaitNameNotFound(new_subgait_name, 'transition_gait')
 
         return old_subgait, new_subgait
 

--- a/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
+++ b/march_shared_classes/src/march_shared_classes/exceptions/gait_exceptions.py
@@ -18,20 +18,21 @@ class GaitNameNotFound(GaitError):
             The message to display.
         """
         if msg is None:
-            msg = 'Could not find gait name: {gn} in map.'.format(gn=gait_name)
+            msg = 'Could not find gait name: {gait} in map.'.format(gait=gait_name)
 
         super(GaitNameNotFound, self).__init__(msg)
 
 
 class SubgaitNameNotFound(GaitError):
-    def __init__(self, subgait_name=None, msg=None):
+    def __init__(self, subgait_name, gait_name, msg=None):
         """Class to raise an error when given subgait name does not exists .
 
         :param msg:
             The message to display.
         """
         if msg is None:
-            msg = 'Could not find subgait name: {gn} in map.'.format(gn=subgait_name)
+            msg = 'Could not find subgait name {subgait} of gait {gait} in map.'.format(subgait=subgait_name,
+                                                                                        gait=gait_name)
 
         super(SubgaitNameNotFound, self).__init__(msg)
 

--- a/march_shared_classes/src/march_shared_classes/gait/gait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/gait.py
@@ -18,7 +18,7 @@ class Gait(object):
         :param list((str, str)) graph: Mapping of subgait names transitions
         """
         self._validate_gait_graph(gait_name, graph)
-        self._validate_trajectory_transition(subgaits, graph)
+        self._validate_trajectory_transition(gait_name, subgaits, graph)
 
         self.gait_name = gait_name
         self.subgaits = subgaits
@@ -69,7 +69,8 @@ class Gait(object):
         from_subgaits_names = gait_content['from_subgait']
         to_subgaits_names = gait_content['to_subgait']
         if len(from_subgaits_names) != len(to_subgaits_names):
-            raise NonValidGaitContent('to_subgait and from_subgait are not of equal length')
+            raise NonValidGaitContent('Gait {gait} has to_subgait and from_subgait which are not of  equal length'
+                                      .format(gait=gait_name))
 
         graph = zip(from_subgaits_names, to_subgaits_names)
         cls._validate_gait_graph(gait_name, graph)
@@ -90,7 +91,7 @@ class Gait(object):
         if gait_name not in gait_version_map:
             raise GaitNameNotFound(gait_name)
         if subgait_name not in gait_version_map[gait_name]:
-            raise SubgaitNameNotFound(subgait_name)
+            raise SubgaitNameNotFound(subgait_name, gait_name)
 
         version = gait_version_map[gait_name][subgait_name]
         subgait_path = os.path.join(gait_directory, gait_name, subgait_name, version + '.subgait')
@@ -119,7 +120,7 @@ class Gait(object):
             raise NonValidGaitContent(msg='Gait {gn} is missing `start` or `end`'.format(gn=gait_name))
 
     @staticmethod
-    def _validate_trajectory_transition(subgaits, graph):
+    def _validate_trajectory_transition(gait_name, subgaits, graph):
         """Compares and validates the trajectory end and start points.
 
         :param dict subgaits: Mapping of subgait names to subgait instances
@@ -134,8 +135,9 @@ class Gait(object):
             to_subgait = subgaits[to_subgait_name]
 
             if not from_subgait.validate_subgait_transition(to_subgait):
-                raise NonValidGaitContent(msg='End setpoint of subgait {sn} to subgait {ns} does not match'
-                                          .format(sn=from_subgait.subgait_name, ns=to_subgait.subgait_name))
+                raise NonValidGaitContent(msg='Gait {gait} with end setpoint of subgait {sn} to subgait {ns} '
+                                              'does not match'.format(gait=gait_name, sn=from_subgait.subgait_name,
+                                                                      ns=to_subgait.subgait_name))
 
     def set_subgait_versions(self, robot, gait_directory, version_map):
         """Updates the given subgait versions and verifies transitions.
@@ -148,8 +150,7 @@ class Gait(object):
         gait_path = os.path.join(gait_directory, self.gait_name)
         for subgait_name, version in version_map.items():
             if subgait_name not in self.subgaits:
-                raise SubgaitNameNotFound(subgait_name,
-                                          'Subgait {0} does not exist for {1}'.format(subgait_name, self.gait_name))
+                raise SubgaitNameNotFound(subgait_name, self.gait_name)
             subgait_path = os.path.join(gait_path, subgait_name, version + '.subgait')
             if not os.path.isfile(subgait_path):
                 raise FileNotFoundError(file_path=subgait_path)
@@ -162,8 +163,10 @@ class Gait(object):
                 to_subgait = new_subgaits.get(to_subgait_name, self.subgaits[to_subgait_name])
 
                 if not from_subgait.validate_subgait_transition(to_subgait):
-                    raise NonValidGaitContent(msg='End setpoint of subgait {sn} to subgait {ns} does not match'
-                                              .format(sn=from_subgait.subgait_name, ns=to_subgait.subgait_name))
+                    raise NonValidGaitContent(msg='Gait {gait} with end setpoint of subgait {sn} to subgait {ns} does '
+                                                  'not match'.format(gait=self.gait_name,
+                                                                     sn=from_subgait.subgait_name,
+                                                                     ns=to_subgait.subgait_name))
 
         self.subgaits.update(new_subgaits)
 

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -183,8 +183,10 @@ class Subgait(object):
         to_subgait_joint_names = set(next_subgait.get_joint_names())
 
         if from_subgait_joint_names != to_subgait_joint_names:
-            raise NonValidGaitContent(msg='Structure of joints does not match between subgait {fn} and subgait {tn}'
-                                      .format(fn=self.subgait_name, tn=next_subgait.subgait_name))
+            raise NonValidGaitContent(msg='Gait {gait}, structure of joints does not match between '
+                                          'subgait {fn} and subgait {tn}'.format(gait=self.gait_name,
+                                                                                 fn=self.subgait_name,
+                                                                                 tn=next_subgait.subgait_name))
 
         for joint_name in to_subgait_joint_names:
             from_joint = self.get_joint(joint_name)
@@ -220,8 +222,8 @@ class Subgait(object):
             new_joint_setpoints = []
             for timestamp in timestamps:
                 if timestamp > self.duration:
-                    raise IndexError('Could not extrapolate timestamp outside max duration of subgait {sn}'
-                                     .format(sn=self.subgait_name))
+                    raise IndexError('Gait {gait}, subgait {subgait} could not extrapolate timestamp outside max '
+                                     'duration'.format(gait=self.gait_name, subgait=self.subgait_name))
 
                 new_joint_setpoints.append(joint.get_interpolated_setpoint(timestamp))
 


### PR DESCRIPTION
## Description
Added the gait name and the subgait name for all the errors inside the gait, subgait and corresponding child classes. During the implementation of the balance gait I encountered some problems which were nicely caught by the gait and subgait software (such as non matching to_subgaits and from_subgaits, or certain subgaits not existing). The problem was that the error message did not display the corresponding gait to the error. Without the gait name the error is kind of useless so I added the necessary information for all custom error classes.

## Changes
* Added gait name to all gait and subgait custom errors
