### PR TITLE
Created new state machine for a fixed number of steps on the ramp down

### DIFF
--- a/march_state_machine/src/march_state_machine/gaits/slope_down_fixed_sm.py
+++ b/march_state_machine/src/march_state_machine/gaits/slope_down_fixed_sm.py
@@ -1,0 +1,28 @@
+import smach
+
+from march_state_machine.state_machines.step_state_machine import StepStateMachine
+from march_state_machine.states.idle_state import IdleState
+
+
+def create():
+    sm_slope_down_fixed = smach.StateMachine(outcomes=['succeeded', 'preempted', 'failed', 'rejected'])
+    sm_slope_down_fixed.register_io_keys(['sounds'])
+    with sm_slope_down_fixed:
+        smach.StateMachine.add('GAIT RD SLOPE DOWN FIXED', StepStateMachine('ramp_door_slope_down_fixed',
+                                                                            ['right_open', 'left_swing',
+                                                                             'right_swing', 'left_close']),
+                               transitions={'succeeded': 'STANDING SLOPE DOWN'})
+
+        smach.StateMachine.add('GAIT RD SLOPE DOWN SINGLE', StepStateMachine('ramp_door_slope_down_single'),
+                               transitions={'succeeded': 'STANDING SLOPE DOWN',
+                                            'rejected': 'STANDING SLOPE DOWN'})
+
+        smach.StateMachine.add('STANDING SLOPE DOWN', IdleState(gait_outcomes=['gait_ramp_door_slope_down_single',
+                                                                               'gait_ramp_door_last_step']),
+                               transitions={'gait_ramp_door_slope_down_single': 'GAIT RD SLOPE DOWN SINGLE',
+                                            'gait_ramp_door_last_step': 'GAIT RD LAST STEP'})
+
+        smach.StateMachine.add('GAIT RD LAST STEP', StepStateMachine('ramp_door_last_step'),
+                               transitions={'rejected': 'STANDING SLOPE DOWN'})
+
+    return sm_slope_down_fixed

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -4,8 +4,8 @@ from std_srvs.srv import Empty, EmptyRequest
 
 from march_shared_resources.srv import CurrentState, PossibleGaits
 
-from .gaits import slope_down_sm
 from .gaits import slope_down_fixed_sm
+from .gaits import slope_down_sm
 from .gaits import tilted_path_left_flexed_knee_step_sm
 from .gaits import tilted_path_left_knee_bend_sm
 from .gaits import tilted_path_left_straight_sm

--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -5,6 +5,7 @@ from std_srvs.srv import Empty, EmptyRequest
 from march_shared_resources.srv import CurrentState, PossibleGaits
 
 from .gaits import slope_down_sm
+from .gaits import slope_down_fixed_sm
 from .gaits import tilted_path_left_flexed_knee_step_sm
 from .gaits import tilted_path_left_knee_bend_sm
 from .gaits import tilted_path_left_straight_sm
@@ -110,6 +111,7 @@ class HealthyStateMachine(smach.StateMachine):
         # RD stands for Ramp and Door
         self.add_state('GAIT RD SLOPE UP', SlopeStateMachine('ramp_door_slope_up'), 'STANDING')
         self.add_state('GAIT RD SLOPE DOWN', slope_down_sm.create(), 'STANDING')
+        self.add_state('GAIT RD SLOPE DOWN FIXED', slope_down_fixed_sm.create(), 'STANDING')
 
         # TP stands for Tilted Path
         self.add_state('GAIT TP LEFT STRAIGHT', tilted_path_left_straight_sm.create(), 'STANDING')
@@ -142,6 +144,7 @@ class HealthyStateMachine(smach.StateMachine):
                                                       'gait_rough_terrain_second_middle_step',
                                                       'gait_rough_terrain_third_middle_step',
                                                       'gait_ramp_door_slope_up', 'gait_ramp_door_slope_down',
+                                                      'gait_ramp_door_slope_down_fixed',
                                                       'gait_tilted_path_left_straight_start',
                                                       'gait_tilted_path_left_flexed_knee_step',
                                                       'gait_tilted_path_left_knee_bend',
@@ -174,6 +177,7 @@ class HealthyStateMachine(smach.StateMachine):
                               'gait_rough_terrain_third_middle_step': 'GAIT RT THIRD MIDDLE STEP',
                               'gait_ramp_door_slope_up': 'GAIT RD SLOPE UP',
                               'gait_ramp_door_slope_down': 'GAIT RD SLOPE DOWN',
+                              'gait_ramp_door_slope_down_fixed': 'GAIT RD SLOPE DOWN FIXED',
                               'gait_tilted_path_left_straight_start': 'GAIT TP LEFT STRAIGHT',
                               'gait_tilted_path_left_flexed_knee_step': 'GAIT TP LEFT FLEXED KNEE STEP',
                               'gait_tilted_path_left_knee_bend': 'GAIT TP LEFT KNEE BEND',


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Last training, Sjaan indicated that it would be nice if there is a fixed number of steps preprogrammed on the ramp, so she doesn't have to trigger the IPD for a closing step. So I added a new state machine named `slope_down_fixed_sm` in which the first four steps are fixed (right_open, left_swing, right_swing and left_close). After these four steps, you're in the state "STANDING SLOPE DOWN", so that you can execute the last step off the ramp or an additional single step on the ramp if necessary. I set it on four fixed steps for now, but since we don't now yet how many steps Sjaan needs on the ramp, it can be extended to six steps (two extra swings). 
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Added a new state machine named `slope_down_fixed_sm` 

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
