### PR TITLE
Feature: PM-511 parametric gait versions

### DIFF
--- a/march_gait_selection/src/march_gait_selection/gait_selection.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection.py
@@ -142,6 +142,7 @@ class GaitSelection(object):
             for subgait_name in version_map[gait_name]:
                 version = version_map[gait_name][subgait_name]
                 if not Subgait.validate_version(gait_path, subgait_name, version):
+                    rospy.logwarn('{0}, {1} does not exist'.format(subgait_name, version))
                     return False
         return True
 

--- a/march_gait_selection/src/march_gait_selection/gait_selection.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 import rospkg
 import rospy
@@ -10,8 +9,7 @@ from march_gait_selection.dynamic_gaits.balance_gait import BalanceGait
 from march_shared_classes.exceptions.gait_exceptions import GaitError, GaitNameNotFound
 from march_shared_classes.exceptions.general_exceptions import FileNotFoundError, PackageNotFoundError
 from march_shared_classes.gait.gait import Gait
-
-PARAMETRIC_GATIS_CHARACTER = '_'
+from march_shared_classes.gait.subgait import Subgait
 
 
 class GaitSelection(object):
@@ -143,21 +141,8 @@ class GaitSelection(object):
 
             for subgait_name in version_map[gait_name]:
                 version = version_map[gait_name][subgait_name]
-                if version[0] == PARAMETRIC_GATIS_CHARACTER:
-                    versions = re.findall(r'\([^\)]*\)', version)
-                    for version in versions:
-                        subgait_path = os.path.join(gait_path, subgait_name, version[1:-1] + '.subgait')
-
-                        if not os.path.isfile(subgait_path):
-                            rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
-
-                            return False
-                else:
-                    subgait_path = os.path.join(gait_path, subgait_name, version + '.subgait')
-
-                    if not os.path.isfile(subgait_path):
-                        rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
-                        return False
+                if not Subgait.validate_version(gait_path, subgait_name, version):
+                    return False
         return True
 
     def __getitem__(self, name):

--- a/march_gait_selection/src/march_gait_selection/gait_selection.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection.py
@@ -1,6 +1,6 @@
 import os
-
 import re
+
 import rospkg
 import rospy
 from urdf_parser_py import urdf
@@ -10,6 +10,8 @@ from march_gait_selection.dynamic_gaits.balance_gait import BalanceGait
 from march_shared_classes.exceptions.gait_exceptions import GaitError, GaitNameNotFound
 from march_shared_classes.exceptions.general_exceptions import FileNotFoundError, PackageNotFoundError
 from march_shared_classes.gait.gait import Gait
+
+PARAMETRIC_GATIS_CHARACTER = '_'
 
 
 class GaitSelection(object):
@@ -118,7 +120,6 @@ class GaitSelection(object):
             default_config = yaml.load(default_yaml_file, Loader=yaml.SafeLoader)
 
         version_map = default_config['gaits']
-        print(version_map)
 
         if not isinstance(version_map, dict):
             raise TypeError('Gait version map should be of type; dictionary')
@@ -142,14 +143,14 @@ class GaitSelection(object):
 
             for subgait_name in version_map[gait_name]:
                 version = version_map[gait_name][subgait_name]
-                if version[0] == '%':
-                    #handel parametric
-                    versions = re.findall('(.*)', str)
+                if version[0] == PARAMETRIC_GATIS_CHARACTER:
+                    versions = re.findall(r'\([^\)]*\)', version)
                     for version in versions:
-                        subgait_path = os.path.join(gait_path, subgait_name, version[2:-2] + '.subgait')
+                        subgait_path = os.path.join(gait_path, subgait_name, version[1:-1] + '.subgait')
 
                         if not os.path.isfile(subgait_path):
                             rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
+
                             return False
                 else:
                     subgait_path = os.path.join(gait_path, subgait_name, version + '.subgait')

--- a/march_gait_selection/src/march_gait_selection/gait_selection.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection.py
@@ -1,5 +1,6 @@
 import os
 
+import re
 import rospkg
 import rospy
 from urdf_parser_py import urdf
@@ -117,6 +118,7 @@ class GaitSelection(object):
             default_config = yaml.load(default_yaml_file, Loader=yaml.SafeLoader)
 
         version_map = default_config['gaits']
+        print(version_map)
 
         if not isinstance(version_map, dict):
             raise TypeError('Gait version map should be of type; dictionary')
@@ -140,11 +142,21 @@ class GaitSelection(object):
 
             for subgait_name in version_map[gait_name]:
                 version = version_map[gait_name][subgait_name]
-                subgait_path = os.path.join(gait_path, subgait_name, version + '.subgait')
+                if version[0] == '%':
+                    #handel parametric
+                    versions = re.findall('(.*)', str)
+                    for version in versions:
+                        subgait_path = os.path.join(gait_path, subgait_name, version[2:-2] + '.subgait')
 
-                if not os.path.isfile(subgait_path):
-                    rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
-                    return False
+                        if not os.path.isfile(subgait_path):
+                            rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
+                            return False
+                else:
+                    subgait_path = os.path.join(gait_path, subgait_name, version + '.subgait')
+
+                    if not os.path.isfile(subgait_path):
+                        rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
+                        return False
         return True
 
     def __getitem__(self, name):

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -12,7 +12,7 @@ from .joint_trajectory import JointTrajectory
 from .limits import Limits
 from .setpoint import Setpoint
 
-PARAMETRIC_GAITS_CHARACTER = '_'
+PARAMETRIC_GAITS_PREFIX = '_pg_'
 
 
 class Subgait(object):
@@ -73,7 +73,7 @@ class Subgait(object):
         :param args:
         :return: A populated Subgait object.
         """
-        if version.startswith(PARAMETRIC_GAITS_CHARACTER):
+        if version.startswith(PARAMETRIC_GAITS_PREFIX):
             base_version, other_version, parameter = Subgait.unpack_parametric_version(version)
             base_path = os.path.join(gait_dir, gait_name, subgait_name, base_version + '.subgait')
             other_path = os.path.join(gait_dir, gait_name, subgait_name, other_version + '.subgait')
@@ -274,7 +274,7 @@ class Subgait(object):
 
         duration = base_subgait.duration * parameter + (1 - parameter) * other_subgait.duration
         gait_type = base_subgait.gait_type if parameter <= 0.5 else other_subgait.gait_type
-        version = '{0}{1}_({2})_({3})'.format(PARAMETRIC_GAITS_CHARACTER, parameter, base_subgait.version,
+        version = '{0}{1}_({2})_({3})'.format(PARAMETRIC_GAITS_PREFIX, parameter, base_subgait.version,
                                               other_subgait.version)
         return Subgait(joints, duration, gait_type, base_subgait.gait_name, base_subgait.subgait_name, version,
                        description)
@@ -334,7 +334,7 @@ class Subgait(object):
     @staticmethod
     def validate_version(gait_path, subgait_name, version):
         """Check whether a gait exists for the gait."""
-        if version[0] == PARAMETRIC_GAITS_CHARACTER:
+        if version.startswith(PARAMETRIC_GAITS_PREFIX):
             base_version, other_version, _ = Subgait.unpack_parametric_version(version)
             base_subgait_path = os.path.join(gait_path, subgait_name, base_version + '.subgait')
             other_subgait_path = os.path.join(gait_path, subgait_name, other_version + '.subgait')
@@ -352,7 +352,7 @@ class Subgait(object):
     @staticmethod
     def unpack_parametric_version(version):
         """Unpack a version to base version, other version and parameter."""
-        parameter_str = re.search(r'{0}[0-9.]*_'.format(PARAMETRIC_GAITS_CHARACTER), version).group(0)
+        parameter_str = re.search(r'{0}[0-9.]*_'.format(PARAMETRIC_GAITS_PREFIX), version).group(0)
         parameter = float(parameter_str[1:-1])
         versions = re.findall(r'\([^\)]*\)', version)
         base_version = versions[0][1:-1]

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -352,8 +352,8 @@ class Subgait(object):
     @staticmethod
     def unpack_parametric_version(version):
         """Unpack a version to base version, other version and parameter."""
-        parameter_str = re.search(r'{0}[0-9.]*_'.format(PARAMETRIC_GAITS_PREFIX), version).group(0)
-        parameter = float(parameter_str[1:-1])
+        parameter_str = re.search(r'^{0}(\d+\.\d+)_'.format(PARAMETRIC_GAITS_PREFIX), version).group(1)
+        parameter = float(parameter_str)
         versions = re.findall(r'\([^\)]*\)', version)
         base_version = versions[0][1:-1]
         other_version = versions[1][1:-1]

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -12,7 +12,7 @@ from .joint_trajectory import JointTrajectory
 from .limits import Limits
 from .setpoint import Setpoint
 
-PARAMETRIC_GATIS_CHARACTER = '_'
+PARAMETRIC_GAITS_CHARACTER = '_'
 
 
 class Subgait(object):
@@ -45,11 +45,8 @@ class Subgait(object):
         :returns
             A populated Subgait object
         """
-        if file_name is None or file_name == '':
+        if file_name is None or not os.path.isfile(file_name):
             raise FileNotFoundError(file_path=file_name)
-        if not os.path.isfile(file_name):
-            raise FileNotFoundError(file_path=file_name)
-
         try:
             gait_name = file_name.split('/')[-3]
             subgait_name = file_name.split('/')[-2]
@@ -76,7 +73,7 @@ class Subgait(object):
         :param args:
         :return: A populated Subgait object.
         """
-        if version[0] == PARAMETRIC_GATIS_CHARACTER:
+        if version.startswith(PARAMETRIC_GAITS_CHARACTER):
             base_version, other_version, parameter = unpack_parametric_version(version)
             base_path = os.path.join(gait_dir, gait_name, subgait_name, base_version + '.subgait')
             other_path = os.path.join(gait_dir, gait_name, subgait_name, other_version + '.subgait')
@@ -334,8 +331,8 @@ class Subgait(object):
     @staticmethod
     def validate_version(gait_path, subgait_name, version):
         """Check whether a gait exists for the gait."""
-        if version[0] == PARAMETRIC_GATIS_CHARACTER:
-            base_version, other_version, _ = unpack_parametric_version(version)
+        if version[0] == PARAMETRIC_GAITS_CHARACTER:
+            base_version, other_version, _ = Subgait.unpack_parametric_version(version)
             base_subgait_path = os.path.join(gait_path, subgait_name, base_version + '.subgait')
             other_subgait_path = os.path.join(gait_path, subgait_name, other_version + '.subgait')
             for subgait_path in [base_subgait_path, other_subgait_path]:
@@ -349,12 +346,12 @@ class Subgait(object):
                 return False
         return True
 
-
-def unpack_parametric_version(version):
-    """Unpack a version to base version, other version and parameter."""
-    parameter_str = re.search(r'{0}[0-9.]*_'.format(PARAMETRIC_GATIS_CHARACTER), version).group(0)
-    parameter = float(parameter_str[1:-1])
-    versions = re.findall(r'\([^\)]*\)', version)
-    base_version = versions[0][1:-1]
-    other_version = versions[1][1:-1]
-    return base_version, other_version, parameter
+    @staticmethod
+    def unpack_parametric_version(version):
+        """Unpack a version to base version, other version and parameter."""
+        parameter_str = re.search(r'{0}[0-9.]*_'.format(PARAMETRIC_GAITS_CHARACTER), version).group(0)
+        parameter = float(parameter_str[1:-1])
+        versions = re.findall(r'\([^\)]*\)', version)
+        base_version = versions[0][1:-1]
+        other_version = versions[1][1:-1]
+        return base_version, other_version, parameter

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -45,10 +45,11 @@ class Subgait(object):
         :returns
             A populated Subgait object
         """
+
+        if file_name is None or file_name == '':
+            raise FileNotFoundError(file_path=file_name)
         if not os.path.isfile(file_name):
             raise FileNotFoundError(file_path=file_name)
-        if file_name is None or file_name == '':
-            return None
 
         try:
             gait_name = file_name.split('/')[-3]

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -74,7 +74,7 @@ class Subgait(object):
         :return: A populated Subgait object.
         """
         if version.startswith(PARAMETRIC_GAITS_CHARACTER):
-            base_version, other_version, parameter = unpack_parametric_version(version)
+            base_version, other_version, parameter = Subgait.unpack_parametric_version(version)
             base_path = os.path.join(gait_dir, gait_name, subgait_name, base_version + '.subgait')
             other_path = os.path.join(gait_dir, gait_name, subgait_name, other_version + '.subgait')
             return cls.from_files_interpolated(robot, base_path, other_path, parameter)

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -45,7 +45,6 @@ class Subgait(object):
         :returns
             A populated Subgait object
         """
-
         if file_name is None or file_name == '':
             raise FileNotFoundError(file_path=file_name)
         if not os.path.isfile(file_name):

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -273,7 +273,10 @@ class Subgait(object):
             base_subgait.version, other_subgait.version, parameter)
 
         duration = base_subgait.duration * parameter + (1 - parameter) * other_subgait.duration
-        return Subgait(joints, duration, base_subgait.gait_name, base_subgait.subgait_name, 'interpolated subgait',
+        gait_type = base_subgait.gait_type if parameter <= 0.5 else other_subgait.gait_type
+        version = '{0}{1}_({2})_({3})'.format(PARAMETRIC_GAITS_CHARACTER, parameter, base_subgait.version,
+                                              other_subgait.version)
+        return Subgait(joints, duration, gait_type, base_subgait.gait_name, base_subgait.subgait_name, version,
                        description)
     # endregion
 

--- a/march_shared_classes/src/march_shared_classes/gait/subgait.py
+++ b/march_shared_classes/src/march_shared_classes/gait/subgait.py
@@ -66,6 +66,16 @@ class Subgait(object):
 
     @classmethod
     def from_name_and_version(cls, robot, gait_dir, gait_name, subgait_name, version, *args):
+        """Load subgait based from file(s) based on name and version.
+
+        :param robot: The robot corresponding to the given subgait file
+        :param gait_dir: The directory with all the gaits
+        :param gait_name: The name of the corresponding gait
+        :param subgait_name: The name of the subgait to load
+        :param version: The version to use, this can be parametric
+        :param args:
+        :return: A populated Subgait object.
+        """
         if version[0] == PARAMETRIC_GATIS_CHARACTER:
             base_version, other_version, parameter = unpack_parametric_version(version)
             base_path = os.path.join(gait_dir, gait_name, subgait_name, base_version + '.subgait')
@@ -322,12 +332,12 @@ class Subgait(object):
     # endregion
 
     @staticmethod
-    def validate_versions(gait_path, subgait_name, version):
+    def validate_version(gait_path, subgait_name, version):
+        """Check whether a gait exists for the gait."""
         if version[0] == PARAMETRIC_GATIS_CHARACTER:
             base_version, other_version, _ = unpack_parametric_version(version)
             base_subgait_path = os.path.join(gait_path, subgait_name, base_version + '.subgait')
             other_subgait_path = os.path.join(gait_path, subgait_name, other_version + '.subgait')
-
             for subgait_path in [base_subgait_path, other_subgait_path]:
                 if not os.path.isfile(subgait_path):
                     rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
@@ -337,9 +347,11 @@ class Subgait(object):
             if not os.path.isfile(subgait_path):
                 rospy.logwarn('{sp} does not exist'.format(sp=subgait_path))
                 return False
+        return True
 
 
 def unpack_parametric_version(version):
+    """Unpack a version to base version, other version and parameter."""
     parameter_str = re.search(r'{0}[0-9.]*_'.format(PARAMETRIC_GATIS_CHARACTER), version).group(0)
     parameter = float(parameter_str[1:-1])
     versions = re.findall(r'\([^\)]*\)', version)

--- a/march_shared_classes/test/subgait_test.py
+++ b/march_shared_classes/test/subgait_test.py
@@ -4,6 +4,7 @@ import rospkg
 from urdf_parser_py import urdf
 
 from march_shared_classes.exceptions.gait_exceptions import NonValidGaitContent, SubgaitInterpolationError
+from march_shared_classes.exceptions.general_exceptions import FileNotFoundError
 from march_shared_classes.gait.joint_trajectory import JointTrajectory
 from march_shared_classes.gait.subgait import Subgait
 
@@ -26,10 +27,12 @@ class SubgaitTest(unittest.TestCase):
         self.assertIsInstance(self.subgait, Subgait)
 
     def test_from_file_invalid_path(self):
-        self.assertIsNone(Subgait.from_file(self.robot, self.resources_folder + '/MV_walk_leftswing_v2.subgait'))
+        with self.assertRaises(FileNotFoundError):
+            Subgait.from_file(self.robot, self.resources_folder + '/MV_walk_leftswing_v2.subgait')
 
     def test_from_file_none_path(self):
-        self.assertIsNone(Subgait.from_file(self.robot, None))
+        with self.assertRaises(FileNotFoundError):
+            Subgait.from_file(self.robot, None)
 
     def test_from_file_no_robot(self):
         self.assertIsNone(Subgait.from_file(None, self.subgait_path))


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-511

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
With https://github.com/project-march/monitor/pull/63 parametric gait versions are created. These versions are of the form: `{parameter}({base version})_({other version})`. Here the Subgait and Gait classes are changed to handle this. The gait selection is also updated. I have moved all the splitting of versions to the Subgait class, so other classes can just use the new versions strings as if nothing changed. This meant that something functionality had to move to the Subgait class.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

* Changed the Subgait class to handel parametric gait versions
* Added a method to get a Subgait from name and versions instead of from a file path.

## Testing
Use the branch in the monitor repo to get parametric gait versions. You can also put a parametric gait version in the `default.yaml`.
<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
