### PR TITLE
round duration in joint trajectory

### DIFF
--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -57,7 +57,7 @@ class JointTrajectory(object):
                 if setpoint.time > new_duration:
                     self.setpoints.remove(setpoint)
 
-        self._duration = round(new_duration, self.self.setpoint_class.digits)
+        self._duration = round(new_duration, self.setpoint_class.digits)
         self.interpolate_setpoints()
 
     @property

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -10,7 +10,6 @@ class JointTrajectory(object):
     """Base class for joint trajectory of a gait."""
 
     setpoint_class = Setpoint
-    digits = 4
 
     def __init__(self, name, limits, setpoints, duration, *args):
         self.name = name

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -10,12 +10,13 @@ class JointTrajectory(object):
     """Base class for joint trajectory of a gait."""
 
     setpoint_class = Setpoint
+    digits = 4
 
     def __init__(self, name, limits, setpoints, duration, *args):
         self.name = name
         self.limits = limits
         self._setpoints = setpoints
-        self._duration = duration
+        self._duration = round(duration, self.digits)
         self.interpolated_position = None
         self.interpolated_velocity = None
         self.interpolate_setpoints()
@@ -56,7 +57,7 @@ class JointTrajectory(object):
                 if setpoint.time > new_duration:
                     self.setpoints.remove(setpoint)
 
-        self._duration = new_duration
+        self._duration = round(new_duration, self.digits)
         self.interpolate_setpoints()
 
     @property

--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -16,7 +16,7 @@ class JointTrajectory(object):
         self.name = name
         self.limits = limits
         self._setpoints = setpoints
-        self._duration = round(duration, self.digits)
+        self._duration = round(duration, self.setpoint_class.digits)
         self.interpolated_position = None
         self.interpolated_velocity = None
         self.interpolate_setpoints()
@@ -57,7 +57,7 @@ class JointTrajectory(object):
                 if setpoint.time > new_duration:
                     self.setpoints.remove(setpoint)
 
-        self._duration = round(new_duration, self.digits)
+        self._duration = round(new_duration, self.self.setpoint_class.digits)
         self.interpolate_setpoints()
 
     @property


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-532

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
The attributes of a setpoint are rounded up to four digits. However the duration of the joint trajectory was not. The result of this is that it could happend that the time at which we requested an interpolated setpoint was a bit after the duration. Normally it is not possible to do this, therefore an error was logged. This is fixed by also rounding the duration in the `JointTrajectory` class.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Round the duration in the `JointTrajectory` class.

## Testing
The close versions of the walk gait that are default in airgait-v and training-v, would cause this error normally. 
<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
