### PR TITLE
gait-selection-develop: gait state machine flow

### DIFF
--- a/march_gait_selection/src/march_gait_selection/gait_selection_node.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection_node.py
@@ -11,6 +11,7 @@ from .state_machine.state_machine_input import StateMachineInput
 NODE_NAME = 'gait_selection'
 GAIT_FILES_MAP_NAME = 'march_gait_files'
 GAIT_DIRECTORY_NAME = 'minimal'
+DEFAULT_UPDATE_RATE = 30.0
 
 
 def set_gait_versions(msg, gait_selection):
@@ -54,14 +55,15 @@ def main():
     rospy.init_node(NODE_NAME)
     gait_package = rospy.get_param('~gait_package', GAIT_FILES_MAP_NAME)
     gait_directory = rospy.get_param('~gait_directory', GAIT_DIRECTORY_NAME)
+    update_rate = rospy.get_param('~update_rate', DEFAULT_UPDATE_RATE)
 
     gait_selection = GaitSelection(gait_package, gait_directory)
     rospy.loginfo('Gait selection initialized with package {0} of directory {1}'.format(gait_package, gait_directory))
 
     state_input = StateMachineInput()
-    gait_state_machine = GaitStateMachine(gait_selection, state_input)
+    gait_state_machine = GaitStateMachine(gait_selection, state_input, update_rate)
 
-    rospy.core.add_preshutdown_hook(lambda s: gait_state_machine.request_shutdown())
+    rospy.core.add_preshutdown_hook(lambda reason: gait_state_machine.request_shutdown())
 
     # Use lambdas to process service calls inline
     rospy.Service('/march/gait_selection/get_version_map', Trigger,

--- a/march_gait_selection/src/march_gait_selection/gait_selection_node.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection_node.py
@@ -1,7 +1,8 @@
 import rospy
 from std_srvs.srv import Trigger
 
-from march_shared_resources.srv import ContainsGait, ContainsGaitResponse, SetGaitVersion
+from march_shared_resources.srv import (ContainsGait, ContainsGaitResponse, PossibleGaits, PossibleGaitsResponse,
+                                        SetGaitVersion)
 
 from .gait_selection import GaitSelection
 from .state_machine.gait_state_machine import GaitStateMachine
@@ -77,5 +78,8 @@ def main():
 
     rospy.Service('/march/gait_selection/contains_gait', ContainsGait,
                   lambda msg: contains_gait(msg, gait_selection))
+
+    rospy.Service('/march/gait_selection/get_possible_gaits', PossibleGaits,
+                  lambda msg: PossibleGaitsResponse(gaits=gait_state_machine.get_possible_gaits()))
 
     gait_state_machine.run()

--- a/march_gait_selection/src/march_gait_selection/state_machine/gait_interface.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/gait_interface.py
@@ -27,7 +27,7 @@ class GaitInterface(object):
                  set as the new goal for the controller, can be None. The flag
                  indicates whether the gait has finished.
         """
-        return None, False
+        return None, True
 
     def stop(self):
         """Called when the gait has been instructed to stop.

--- a/march_gait_selection/src/march_gait_selection/state_machine/gait_interface.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/gait_interface.py
@@ -1,10 +1,6 @@
 class GaitInterface(object):
-    def start(self, starting_position):
-        """Called when the gait has been selected for execution.
-
-        The gait should start at the given starting position.
-        :param starting_position: starting positions of all joints
-        """
+    def start(self):
+        """Called when the gait has been selected for execution."""
         pass
 
     def starting_position(self):

--- a/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
@@ -7,16 +7,19 @@ from .home_gait import HomeGait
 class GaitStateMachine(object):
     UNKNOWN = 'unknown'
 
-    def __init__(self, gait_selection, state_input):
+    def __init__(self, gait_selection, state_input, update_rate):
         """Generates a state machine from given gaits and resets it to UNKNOWN state.
 
         In order to start the state machine see `run`.
 
         :param GaitSelection gait_selection: Selection of loaded gaits to build from
         :param StateMachineInput state_input: Input interface for controlling the states
+        :param float update_rate: update rate in Hz
         """
         self._gait_selection = gait_selection
         self._input = state_input
+        self._update_rate = update_rate
+
         self._home_gaits = {}
         self._idle_transitions = {}
         self._gait_transitions = {}
@@ -39,7 +42,7 @@ class GaitStateMachine(object):
 
     def run(self):
         """Runs the state machine until shutdown is requested."""
-        rate = rospy.Rate(30.0)
+        rate = rospy.Rate(self._update_rate)
         last_update_time = rospy.Time.now()
         while not self._shutdown_requested:
             now = rospy.Time.now()

--- a/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
@@ -1,10 +1,7 @@
 import rospy
 
-from march_gait_selection.gait_selection import GaitSelection
-
 from .gait_state_machine_error import GaitStateMachineError
 from .home_gait import HomeGait
-from .state_machine_input import StateMachineInput
 
 
 class GaitStateMachine(object):
@@ -88,11 +85,14 @@ class GaitStateMachine(object):
         if self._input.stop_requested():
             if self._current_gait.stop():
                 rospy.loginfo('Gait `{0}` responded to stop'.format(self._current_gait.name()))
+                self._input.stop_accepted()
             else:
                 rospy.loginfo('Gait `{0}` does not respond to stop'.format(self._current_gait.name()))
 
         trajectory, should_stop = self._current_gait.update(elapsed_time)
         # schedule trajectory if any
+        if trajectory is not None:
+            rospy.loginfo('Received new trajectory to schedule')
 
         if should_stop:
             self._current_state = self._gait_transitions[self._current_state]

--- a/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
@@ -92,7 +92,7 @@ class GaitStateMachine(object):
         trajectory, should_stop = self._current_gait.update(elapsed_time)
         # schedule trajectory if any
         if trajectory is not None:
-            rospy.loginfo('Received new trajectory to schedule')
+            rospy.loginfo('Received new trajectory to schedule: ' + str(trajectory))
 
         if should_stop:
             self._current_state = self._gait_transitions[self._current_state]

--- a/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
@@ -70,6 +70,11 @@ class GaitStateMachine(object):
             else:
                 self._input.gait_rejected()
                 rospy.loginfo('Cannot execute gait `{0}` from idle state `{1}`'.format(gait_name, self._current_state))
+        elif self._input.unknown_requested():
+            self._input.gait_accepted()
+            self._current_state = self.UNKNOWN
+            self._input.gait_finished()
+            rospy.loginfo('Transitioned to `{0}`'.format(self.UNKNOWN))
 
     def _process_gait_state(self, elapsed_time):
         if self._current_gait is None:

--- a/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/gait_state_machine.py
@@ -30,6 +30,16 @@ class GaitStateMachine(object):
         self._is_idle = True
         self._shutdown_requested = False
 
+    def get_possible_gaits(self):
+        """Returns possible names of gaits that can be executed.
+
+        :returns List of names, or empty list when a gait is executing.
+        """
+        if self._is_idle:
+            return list(self._idle_transitions[self._current_state])
+        else:
+            return []
+
     def run(self):
         """Runs the state machine until shutdown is requested."""
         rate = rospy.Rate(30.0)
@@ -121,11 +131,11 @@ class GaitStateMachine(object):
 
     def _generate_home_gaits(self, idle_positions):
         self._idle_transitions[self.UNKNOWN] = set()
-        home_gaits = {}
+        self._home_gaits = {}
         for idle_name, position in idle_positions.items():
             home_gait = HomeGait(idle_name, position)
             home_gait_name = home_gait.name()
-            home_gaits[home_gait_name] = home_gait
+            self._home_gaits[home_gait_name] = home_gait
             if home_gait_name in self._gait_transitions:
                 raise GaitStateMachineError('Gaits cannot have the same name as home gait `{0}`'.format(home_gait_name))
             self._gait_transitions[home_gait_name] = idle_name

--- a/march_gait_selection/src/march_gait_selection/state_machine/home_gait.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/home_gait.py
@@ -36,6 +36,8 @@ class HomeGait(GaitInterface):
         self._elapsed_time += elapsed_time
         if self._elapsed_time >= self._duration:
             return None, True
+        else:
+            return None, False
 
     def _get_trajectory_msg(self):
         msg = JointTrajectory()

--- a/march_gait_selection/src/march_gait_selection/state_machine/home_gait.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/home_gait.py
@@ -1,10 +1,16 @@
+import rospy
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
 from .gait_interface import GaitInterface
 
 
 class HomeGait(GaitInterface):
-    def __init__(self, name, position):
+    def __init__(self, name, position, duration=3.0):
         self._name = 'home_{name}'.format(name=name)
         self._position = position
+        self._duration = duration
+        self._elapsed_time = 0.0
+        self._has_started = False
 
     def name(self):
         return self._name
@@ -14,3 +20,30 @@ class HomeGait(GaitInterface):
 
     def final_position(self):
         return self._position
+
+    def start(self):
+        self._elapsed_time = 0.0
+        self._has_started = False
+
+    def update(self, elapsed_time):
+        if not self._has_started:
+            self._has_started = True
+            return self._get_trajectory_msg(), False
+
+        self._elapsed_time += elapsed_time
+        if self._elapsed_time >= self._duration:
+            return None, True
+
+    def _get_trajectory_msg(self):
+        msg = JointTrajectory()
+        msg.joint_names = sorted(list(self._position.keys()))
+
+        point = JointTrajectoryPoint()
+        point.time_from_start = rospy.Duration.from_sec(self._duration)
+        point.positions = [self._position[name] for name in msg.joint_names]
+        point.velocities = [0.0] * len(msg.joint_names)
+        point.accelerations = [0.0] * len(msg.joint_names)
+        point.effort = [0.0] * len(msg.joint_names)
+
+        msg.points = [point]
+        return msg

--- a/march_gait_selection/src/march_gait_selection/state_machine/setpoints_gait.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/setpoints_gait.py
@@ -4,6 +4,17 @@ from .gait_interface import GaitInterface
 
 
 class SetpointsGait(GaitInterface, Gait):
+    def __init__(self, gait_name, subgaits, graph):
+        super(SetpointsGait, self).__init__(gait_name, subgaits, graph)
+        self._current_subgait = None
+        self._should_stop = False
+        self._subgait_duration = 0.0
+
+    def start(self):
+        self._current_subgait = None
+        self._should_stop = False
+        self._subgait_duration = 0.0
+
     def starting_position(self):
         subgait = self.subgaits[self.graph.start_subgaits()[0]]
         return dict([(joint.name, joint.setpoints[0].position) for joint in subgait.joints])
@@ -14,3 +25,34 @@ class SetpointsGait(GaitInterface, Gait):
 
     def name(self):
         return self.gait_name
+
+    def update(self, elapsed_time):
+        if self._current_subgait is None:
+            self._current_subgait = self.graph.start_subgaits()[0]
+            self._subgait_duration = 0.0
+            return self.subgaits[self._current_subgait].to_joint_trajectory_msg(), False
+
+        self._subgait_duration += elapsed_time
+        if self._subgait_duration >= self.subgaits[self._current_subgait].duration:
+            if self._should_stop:
+                next_subgait = self.graph[(self._current_subgait, self.graph.STOP)]
+                self._should_stop = False
+            else:
+                next_subgait = self.graph[(self._current_subgait, self.graph.TO)]
+
+            if next_subgait == self.graph.END:
+                return None, True
+            trajectory = self.subgaits[next_subgait].to_joint_trajectory_msg()
+            self._current_subgait = next_subgait
+            self._subgait_duration = 0.0
+            return trajectory, False
+        else:
+            return None, False
+
+    def stop(self):
+        transition = self.graph[(self._current_subgait, self.graph.STOP)]
+        if transition is not None:
+            self._should_stop = True
+            return True
+        else:
+            return False

--- a/march_gait_selection/src/march_gait_selection/state_machine/state_machine_input.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/state_machine_input.py
@@ -1,0 +1,96 @@
+import rospy
+
+from march_shared_resources.msg import GaitInstruction, GaitInstructionResponse
+
+
+class StateMachineInput(object):
+
+    def __init__(self):
+        self._stopped = False
+        self._paused = False
+        self._unknown = False
+        self._transition_index = 0
+        self._gait = None
+
+        self._instruction_subscriber = rospy.Subscriber('/march/input_device/instruction',
+                                                        GaitInstruction,
+                                                        self._callback_input_device_instruction)
+        self._instruction_response_publisher = rospy.Publisher('/march/input_device/instruction_response',
+                                                               GaitInstructionResponse,
+                                                               queue_size=20)
+
+    def get_transition_integer(self):
+        """Used to return the transition in the integer-format."""
+        if self._transition_index == GaitInstruction.INCREMENT_STEP_SIZE:
+            return 1
+
+        if self._transition_index == GaitInstruction.DECREMENT_STEP_SIZE:
+            return -1
+
+        return 0
+
+    def stop_requested(self):
+        """Returns True when the current gait should stop, otherwise False."""
+        return self._stopped
+
+    def pause_requested(self):
+        """Returns True when the input requests to pause the current gait, otherwise False."""
+        return self._paused
+
+    def unknown_requested(self):
+        """Returns True when the input requests to transition to the UNKNOWN state, otherwise False."""
+        return self._unknown
+
+    def transition_requested(self):
+        """Returns True when the input requests a gait transition, otherwise False."""
+        return self._transition_index != 0
+
+    def gait_selected(self):
+        """Returns True when the input has a gait selected, otherwise False."""
+        return self._gait is not None
+
+    def gait_name(self):
+        """Returns a name of the gait that has been selected, if one was selected, otherwise None."""
+        return self._gait
+
+    def reset(self):
+        """Resets the input state to its original state on init."""
+        self._stopped = False
+        self._paused = False
+        self._unknown = False
+        self._transition_index = 0
+        self._gait = None
+
+    def gait_accepted(self):
+        """Callback called when the state machine accepts the requested gait."""
+        response = GaitInstructionResponse(result=GaitInstructionResponse.GAIT_ACCEPTED)
+        self._instruction_response_publisher.publish(response)
+        self.reset()
+
+    def gait_rejected(self):
+        """Callback called when the state machine rejects the requested gait."""
+        response = GaitInstructionResponse(result=GaitInstructionResponse.GAIT_REJECTED)
+        self._instruction_response_publisher.publish(response)
+        self.reset()
+
+    def gait_finished(self):
+        """Callback called when the state machine finishes a gait."""
+        response = GaitInstructionResponse(result=GaitInstructionResponse.GAIT_FINISHED)
+        self._instruction_response_publisher.publish(response)
+        self.reset()
+
+    def _callback_input_device_instruction(self, msg):
+        if msg.type == GaitInstruction.STOP:
+            self._stopped = True
+        elif msg.type == GaitInstruction.GAIT:
+            self._gait = msg.gait_name
+        elif msg.type == GaitInstruction.PAUSE:
+            self._paused = True
+        elif msg.type == GaitInstruction.CONTINUE:
+            self._paused = False
+        elif msg.type == GaitInstruction.INCREMENT_STEP_SIZE:
+            self._transition_index = GaitInstruction.INCREMENT_STEP_SIZE
+        elif msg.type == GaitInstruction.DECREMENT_STEP_SIZE:
+            self._transition_index = GaitInstruction.DECREMENT_STEP_SIZE
+        elif msg.type == GaitInstruction.UNKNOWN:
+            self._unknown = True

--- a/march_gait_selection/src/march_gait_selection/state_machine/state_machine_input.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/state_machine_input.py
@@ -45,7 +45,7 @@ class StateMachineInput(object):
         """Returns True when the input requests a gait transition, otherwise False."""
         return self._transition_index != 0
 
-    def gait_selected(self):
+    def gait_requested(self):
         """Returns True when the input has a gait selected, otherwise False."""
         return self._gait is not None
 

--- a/march_gait_selection/src/march_gait_selection/state_machine/state_machine_input.py
+++ b/march_gait_selection/src/march_gait_selection/state_machine/state_machine_input.py
@@ -61,6 +61,9 @@ class StateMachineInput(object):
         self._transition_index = 0
         self._gait = None
 
+    def stop_accepted(self):
+        self._stopped = False
+
     def gait_accepted(self):
         """Callback called when the state machine accepts the requested gait."""
         response = GaitInstructionResponse(result=GaitInstructionResponse.GAIT_ACCEPTED)


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-505

## Description
This PR adds the ability to give input to the new state machine in the gait selection. Setpoint gaits and homing gaits return a trajectory that should be followed but is not yet communicated to the controller.

## Changes
* Add `GaitStateMachine.run`
* Implement `start`, `update` and `stop` on `SetpointsGait` and `HomeGait`
* Add `StateMachineInput` class for giving input via ROS topics

## Testing
This new feature can also be run. First you have to checkout the `feature/new-state-machine` branch on project-march/gait-files. Then you can launch with:

    roslaunch march_gait_selection march_gait_selection.launch

and request for possible gaits:

     rosservice call /march/gait_selection/get_possible_gaits

And perform a gait
```
rostopic pub --once /march/input_device/instruction march_shared_resources/GaitInstruction "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
type: 1
gait_name: 'home_stand'
id: ''"
```

You should see some logging about the gait being performed :tada:

<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
