### PR TITLE
Add a separate slalom walk gait to the state machine

### DIFF
--- a/march_state_machine/src/march_state_machine/healthy_sm.py
+++ b/march_state_machine/src/march_state_machine/healthy_sm.py
@@ -68,6 +68,9 @@ class HealthyStateMachine(smach.StateMachine):
         self.add_state('GAIT WALK SMALL', walking_state_machine, 'STANDING', custom_start_label='walk_small')
         self.add_state('GAIT WALK LARGE', walking_state_machine, 'STANDING', custom_start_label='walk_large')
 
+        # Separate walking gait for the slalom obstacle
+        self.add_state('GAIT SLALOM WALK', WalkStateMachine('slalom_walk'), 'STANDING')
+
         self.add_state('GAIT SIT', StepStateMachine('sit', ['sit_down', 'sit_home']), 'SITTING', rejected='STANDING')
         self.add_state('GAIT STAND', StepStateMachine('stand', ['prepare_stand_up', 'stand_up']), 'STANDING',
                        rejected='SITTING')
@@ -153,7 +156,8 @@ class HealthyStateMachine(smach.StateMachine):
                                                       'gait_tilted_path_right_knee_bend',
                                                       'gait_tilted_path_first_start',
                                                       'gait_tilted_path_first_end',
-                                                      'gait_balanced_walk'],
+                                                      'gait_balanced_walk',
+                                                      'gait_slalom_walk'],
                                        balance_gaits=['gait_balanced_walk']),
                  transitions={'gait_sit': 'GAIT SIT',
                               'gait_walk': 'GAIT WALK',
@@ -187,6 +191,7 @@ class HealthyStateMachine(smach.StateMachine):
                               'gait_tilted_path_first_start': 'GAIT TP SIDEWAYS START',
                               'gait_tilted_path_first_end': 'GAIT TP SIDEWAYS END',
                               'gait_balanced_walk': 'GAIT BALANCED WALK',
+                              'gait_slalom_walk': 'GAIT SLALOM WALK',
                               'failed': 'UNKNOWN'})
         self.close()
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Since the MIV walk gait worked better for Sjaan during the slalom obstacle, I add  a separate "slalom walk' gait to the state machine. In this way, Sjaan can walk straight with the faster walking gait when selecting "walk" and switch to the MIV gait for the slalom by selecting 'slalom walk'. During training the monitor can of course change the version of the 'walk' to MIV, but this not allowed during the Cybathlon. So Sjaan can switch between the two version by herself with this implementation.
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Add 'slalom walk' gait to the state machine
## Testing

<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
