### PR TITLE
Add check if gait type exists

### DIFF
--- a/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
+++ b/march_gain_scheduling/src/march_gain_scheduling/dynamic_pid_reconfigurer.py
@@ -21,9 +21,10 @@ class DynamicPIDReconfigurer:
 
     def gait_selection_callback(self, data):
         new_gait_type = data.goal.gait_type
-        if new_gait_type is None or new_gait_type == '':
+        if new_gait_type is None or not rospy.has_param('~gait_types/{gait_type}'.format(gait_type=new_gait_type)):
+            rospy.logwarn('The gait has unknown gait type of `{gait_type}`, default is set to walk_like'.format(
+                gait_type=new_gait_type))
             new_gait_type = 'walk_like'
-            rospy.logwarn('The gait has no gait type, default is set to walk_like')
 
         if self._gait_type != new_gait_type or not self.interpolation_done:
             self._gait_type = new_gait_type


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-538

## Description
When gaits had unknown gait types, the gains would be interpolated to some unknown value. So I fixed it by checking if the gait type exists.

## Changes
* Add check if parameter exists

## Testing
Run the simulation with `gain_scheduling:=true` and change a gait type to some unknown type.
