### PR TITLE
[gait-selection-develop] Feature: error handling

### DIFF
--- a/march_gait_selection/src/march_gait_selection/gait_selection_node.py
+++ b/march_gait_selection/src/march_gait_selection/gait_selection_node.py
@@ -1,6 +1,7 @@
 import rospy
 from std_srvs.srv import Trigger
 
+from march_shared_resources.msg import Error
 from march_shared_resources.srv import (ContainsGait, ContainsGaitResponse, PossibleGaits, PossibleGaitsResponse,
                                         SetGaitVersion)
 
@@ -51,6 +52,15 @@ def contains_gait(request, gait_selection):
     return ContainsGaitResponse(True)
 
 
+def error_cb(gait_state_machine, msg):
+    if msg.type == Error.NON_FATAL:
+        rospy.logerr('Stopping current gait. reason: {0}'.format(msg.error_message))
+        gait_state_machine.stop()
+    elif msg.type == Error.FATAL:
+        rospy.logerr('Requesting shutdown. reason: {0}'.format(msg.error_message))
+        gait_state_machine.request_shutdown()
+
+
 def main():
     rospy.init_node(NODE_NAME)
     gait_package = rospy.get_param('~gait_package', DEFAULT_GAIT_FILES_PACKAGE)
@@ -64,6 +74,8 @@ def main():
     gait_state_machine = GaitStateMachine(gait_selection, state_input, update_rate)
 
     rospy.core.add_preshutdown_hook(lambda reason: gait_state_machine.request_shutdown())
+
+    rospy.Subscriber('/march/error', Error, lambda msg: error_cb(gait_state_machine, msg))
 
     # Use lambdas to process service calls inline
     rospy.Service('/march/gait_selection/get_version_map', Trigger,


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-507

## Description
The new gait selection state machine now responds to the `/march/error` topic and stops the current gait when a non fatal error is published and shuts down when a fatal error is published.

## Changes
* Add error subscriber
* Add `stop` method

## Testing
Start a `roscore`. Open another shell and upload the URDF and joint names (necessary for safety node)
```
roslaunch march_launch upload_march_urdf.launch
rosrun march_simulation upload_joint_names
```
Now launch the gait selection, safety and possibly an input device. To see how it responds. You can checkout `remove-gait-prefix` in project-march/monitor to be able to issue gait commands.
