### PR TITLE
New tuning for knees and hip FEs in groundgait yaml

### DIFF
--- a/march_gain_scheduling/config/groundgait.yaml
+++ b/march_gain_scheduling/config/groundgait.yaml
@@ -11,18 +11,18 @@ gait_types:
   walk_like:
     left_ankle: {p: 600, i: 0, d: 20}
     left_hip_aa: {p: 330, i: 0, d: 10}
-    left_hip_fe: {p: 135, i: 0, d: 10}
-    left_knee: {p: 80, i: 0, d: 10}
+    left_hip_fe: {p: 200, i: 0, d: 15}
+    left_knee: {p: 600, i: 0, d: 30}
     right_ankle: {p: 600, i: 0, d: 20}
     right_hip_aa: {p: 330, i: 0, d: 10}
-    right_hip_fe: {p: 135, i: 0, d: 10}
-    right_knee: {p: 80, i: 0, d: 10}
+    right_hip_fe: {p: 200, i: 0, d: 15}
+    right_knee: {p: 600, i: 0, d: 30}
   stairs_like:
     left_ankle: {p: 600, i: 0, d: 20}
     left_hip_aa: {p: 330, i: 0, d: 5}
-    left_hip_fe: {p: 135, i: 0, d: 10}
-    left_knee: {p: 80, i: 0, d: 10}
+    left_hip_fe: {p: 200, i: 0, d: 15}
+    left_knee: {p: 600, i: 0, d: 30}
     right_ankle: {p: 600, i: 0, d: 20}
     right_hip_aa: {p: 330, i: 0, d: 5}
-    right_hip_fe: {p: 135, i: 0, d: 10}
-    right_knee: {p: 80, i: 0, d: 10}
+    right_hip_fe: {p: 200, i: 0, d: 15}
+    right_knee: {p: 600, i: 0, d: 30}


### PR DESCRIPTION
New tuning for the knees and hip fe's

<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-non-existent

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
After tuning on the exo in the airgait stand I determined that these proposed values for the PD controller are suitable. They both exhibit a maximum error of around 1,7 degrees (I wasn't able to achieve better control at this stage).

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Changes in the groundgait.yaml file:
- knees have a P of 600 and a D of 30
- hip fe's have a P of 200 and a D of 15

## Testing

<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->
Testing was done already on exo in the airgait stand.


<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
