### PR TITLE
Use defined setters in constructor

### DIFF
--- a/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
+++ b/march_shared_classes/src/march_shared_classes/gait/joint_trajectory.py
@@ -14,11 +14,10 @@ class JointTrajectory(object):
     def __init__(self, name, limits, setpoints, duration, *args):
         self.name = name
         self.limits = limits
-        self._setpoints = setpoints
-        self._duration = round(duration, self.setpoint_class.digits)
         self.interpolated_position = None
         self.interpolated_velocity = None
-        self.interpolate_setpoints()
+        self.setpoints = setpoints
+        self._duration = round(duration, self.setpoint_class.digits)
 
     @classmethod
     def from_setpoints(cls, name, limits, setpoints, duration, *args):

--- a/march_shared_classes/src/march_shared_classes/gait/setpoint.py
+++ b/march_shared_classes/src/march_shared_classes/gait/setpoint.py
@@ -5,9 +5,9 @@ class Setpoint(object):
     digits = 4
 
     def __init__(self, time, position, velocity):
-        self._time = round(time, self.digits)
-        self._position = round(position, self.digits)
-        self._velocity = round(velocity, self.digits)
+        self.time = time
+        self.position = position
+        self.velocity = velocity
 
     @property
     def time(self):


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Let the `Setpoint` and `JointTrajectory` classes use their own setters in their constructor. This removes code duplication.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Replace assignments of variables in constructor of `Setpoint` and `JointTrajactory` with implicit calls to the setters of the variables.


<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
